### PR TITLE
changed http -> https, repo.spongepowered.org

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ sourceSets {
 
 repositories {
     mavenCentral()
-    maven { url 'http://repo.spongepowered.org/maven' }
+    maven { url 'https://repo.spongepowered.org/maven' }
     maven { url 'https://libraries.minecraft.net/' }
     maven { url 'https://jitpack.io' }
 }


### PR DESCRIPTION
Partial solution to issue #10.

`/Minestom` is still outdated, using http instead of https.

It needs an update too, but I assume you guys are going to do a PR yourselves.