### PR TITLE
Merge pull request #16 from PestoNotPasta/blocks

### DIFF
--- a/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
@@ -62,12 +62,7 @@ public class CakeBlockHandler extends VanillaBlockHandler {
 
         // Player is eating cake
         if (food < 20) {
-            // Try drop candle from candle cake
-            if (block != Block.CAKE) {
-                instance.setBlock(point, Block.CAKE.withProperty("bites", "1"));
-                ItemStack candle = ItemStack.of(candleCakes.get(block));
-                new ItemEntity(candle).setInstance(instance);
-            }
+            tryDropCandle(block, instance, point);
 
             // Update hunger values
             int newFood = Math.max(20, food + 2);
@@ -77,4 +72,23 @@ public class CakeBlockHandler extends VanillaBlockHandler {
         }
         return true;
     }
+
+    @Override
+    public void onDestroy(@NotNull Destroy destroy) {
+        Block block = destroy.getBlock();
+        Instance instance = destroy.getInstance();
+        Point point = destroy.getBlockPosition();
+
+        tryDropCandle(block, instance, point);
+    }
+
+    private void tryDropCandle(Block block, Instance instance, Point point) {
+        if (block != Block.CAKE) {
+            instance.setBlock(point, Block.CAKE.withProperty("bites", "1"));
+            ItemStack candle = ItemStack.of(candleCakes.get(block));
+            new ItemEntity(candle).setInstance(instance);
+        }
+    }
+
+
 }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
@@ -89,6 +89,4 @@ public class CakeBlockHandler extends VanillaBlockHandler {
             new ItemEntity(candle).setInstance(instance);
         }
     }
-
-
 }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/CakeBlockHandler.java
@@ -1,0 +1,80 @@
+package net.minestom.vanilla.blocks;
+
+import net.minestom.server.coordinate.Point;
+import net.minestom.server.entity.ItemEntity;
+import net.minestom.server.entity.Player;
+import net.minestom.server.instance.Instance;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.item.Material;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+
+import static java.util.Map.entry;
+
+public class CakeBlockHandler extends VanillaBlockHandler {
+
+    private static final Map<Block, Material> candleCakes = Map.ofEntries(
+            entry(Block.CANDLE_CAKE, Material.CANDLE),
+            entry(Block.WHITE_CANDLE_CAKE, Material.WHITE_CANDLE),
+            entry(Block.ORANGE_CANDLE_CAKE, Material.ORANGE_CANDLE),
+            entry(Block.MAGENTA_CANDLE_CAKE, Material.MAGENTA_CANDLE),
+            entry(Block.LIGHT_BLUE_CANDLE_CAKE, Material.LIGHT_BLUE_CANDLE),
+            entry(Block.YELLOW_CANDLE_CAKE, Material.YELLOW_CANDLE),
+            entry(Block.LIME_CANDLE_CAKE, Material.LIME_CANDLE),
+            entry(Block.PINK_CANDLE_CAKE, Material.PINK_CANDLE),
+            entry(Block.GRAY_CANDLE_CAKE, Material.GRAY_CANDLE),
+            entry(Block.LIGHT_GRAY_CANDLE_CAKE, Material.LIGHT_GRAY_CANDLE),
+            entry(Block.CYAN_CANDLE_CAKE, Material.CYAN_CANDLE),
+            entry(Block.PURPLE_CANDLE_CAKE, Material.PURPLE_CANDLE),
+            entry(Block.BLUE_CANDLE_CAKE, Material.BLUE_CANDLE),
+            entry(Block.BROWN_CANDLE_CAKE, Material.BROWN_CANDLE),
+            entry(Block.GREEN_CANDLE_CAKE, Material.GREEN_CANDLE),
+            entry(Block.BLACK_CANDLE_CAKE, Material.BLACK_CANDLE)
+    );
+
+    private static final ItemStack flint_and_steel = ItemStack.of(Material.FLINT_AND_STEEL);
+
+    protected CakeBlockHandler(VanillaBlocks.@NotNull BlockContext context) {
+        super(context);
+    }
+
+    @Override
+    public boolean onInteract(@NotNull Interaction interaction) {
+        Player player = interaction.getPlayer();
+        Block block = interaction.getBlock();
+        Point point = interaction.getBlockPosition();
+        Instance instance = interaction.getInstance();
+
+        int food = player.getFood();
+        float saturation = player.getFoodSaturation();
+        ItemStack item = player.getItemInMainHand();
+
+        // Player is trying to light candle cake
+        if (item.isSimilar(flint_and_steel) && candleCakes.containsKey(block) &&
+                !Boolean.parseBoolean(block.getProperty("lit"))) {
+            instance.setBlock(point, block.withProperty("lit", "true"));
+            
+            // TODO: Handle tool durability
+            return true;
+        }
+
+        // Player is eating cake
+        if (food < 20) {
+            // Try drop candle from candle cake
+            if (block != Block.CAKE) {
+                instance.setBlock(point, Block.CAKE.withProperty("bites", "1"));
+                ItemStack candle = ItemStack.of(candleCakes.get(block));
+                new ItemEntity(candle).setInstance(instance);
+            }
+
+            // Update hunger values
+            int newFood = Math.max(20, food + 2);
+            float newSaturation = Math.max(20f, saturation + 0.4f);
+            player.setFood(newFood);
+            player.setFoodSaturation(newSaturation);
+        }
+        return true;
+    }
+}

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
@@ -1,13 +1,9 @@
 package net.minestom.vanilla.blocks;
 
-import net.minestom.server.event.Event;
-import net.minestom.server.event.EventListener;
-import net.minestom.server.event.EventNode;
 import net.minestom.server.event.player.PlayerBlockPlaceEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
 import sun.misc.Unsafe;
@@ -16,8 +12,6 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * All blocks available in the vanilla reimplementation
@@ -75,8 +69,29 @@ public enum VanillaBlocks {
     CHEST(Block.CHEST, ChestBlockHandler::new),
     TRAPPED_CHEST(Block.TRAPPED_CHEST, TrappedChestBlockHandler::new),
     ENDER_CHEST(Block.ENDER_CHEST, EnderChestBlockHandler::new),
-    JUKEBOX(Block.JUKEBOX, JukeboxBlockHandler::new);
+    JUKEBOX(Block.JUKEBOX, JukeboxBlockHandler::new),
 
+    // Start of cakes
+    CAKE(Block.CAKE, CakeBlockHandler::new),
+    CANDLE_CAKE(Block.CANDLE_CAKE, CakeBlockHandler::new),
+    WHITE_CANDLE_CAKE(Block.WHITE_CANDLE_CAKE, CakeBlockHandler::new),
+    ORANGE_CANDLE_CAKE(Block.ORANGE_CANDLE_CAKE, CakeBlockHandler::new),
+    MAGENTA_CANDLE_CAKE(Block.MAGENTA_CANDLE_CAKE, CakeBlockHandler::new),
+    LIGHT_BLUE_CANDLE_CAKE(Block.LIGHT_BLUE_CANDLE_CAKE, CakeBlockHandler::new),
+    YELLOW_CANDLE_CAKE(Block.YELLOW_CANDLE_CAKE, CakeBlockHandler::new),
+    LIME_CANDLE_CAKE(Block.LIME_CANDLE_CAKE, CakeBlockHandler::new),
+    PINK_CANDLE_CAKE(Block.PINK_CANDLE_CAKE, CakeBlockHandler::new),
+    GRAY_CANDLE_CAKE(Block.GRAY_CANDLE_CAKE, CakeBlockHandler::new),
+    LIGHT_GRAY_CANDLE_CAKE(Block.LIGHT_GRAY_CANDLE_CAKE, CakeBlockHandler::new),
+    CYAN_CANDLE_CAKE(Block.CYAN_CANDLE_CAKE, CakeBlockHandler::new),
+    PURPLE_CANDLE_CAKE(Block.PURPLE_CANDLE_CAKE, CakeBlockHandler::new),
+    BLUE_CANDLE_CAKE(Block.BLUE_CANDLE_CAKE, CakeBlockHandler::new),
+    BROWN_CANDLE_CAKE(Block.BROWN_CANDLE_CAKE, CakeBlockHandler::new),
+    GREEN_CANDLE_CAKE(Block.GREEN_CANDLE_CAKE, CakeBlockHandler::new),
+    BLACK_CANDLE_CAKE(Block.BLACK_CANDLE_CAKE, CakeBlockHandler::new)
+    // End of cakes
+
+    ;
     private final @NotNull Block block;
     private final @NotNull Context2Handler context2handler;
 
@@ -100,11 +115,13 @@ public enum VanillaBlocks {
      */
     public interface BlockContext {
         @NotNull Block block();
+
         @NotNull VanillaReimplementation vri();
     }
 
     /**
      * Creates a block handler from the context
+     *
      * @param context the context
      * @return the block handler
      */

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
@@ -115,13 +115,11 @@ public enum VanillaBlocks {
      */
     public interface BlockContext {
         @NotNull Block block();
-
         @NotNull VanillaReimplementation vri();
     }
 
     /**
      * Creates a block handler from the context
-     *
      * @param context the context
      * @return the block handler
      */


### PR DESCRIPTION
New BlockHandler for the cake block. This handles the following:

- Players attempting to eat cake and candle cakes
- Dropping candles when destroying/eating a candle cake
- Lighting a candle cake (Does not handle flint and steel durability changes)

I haven't been able to test this fully in game as I've been having trouble in building a workable jar. 