### PR TITLE
Update Minestom to 1.21.5

### DIFF
--- a/block-update-system/src/main/java/net/minestom/vanilla/BlockUpdateFeature.java
+++ b/block-update-system/src/main/java/net/minestom/vanilla/BlockUpdateFeature.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla;
 
-import net.minestom.server.utils.NamespaceID;
+
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.blockupdatesystem.BlockUpdateManager;
 import net.minestom.vanilla.logging.Loading;
 import net.minestom.vanilla.randomticksystem.RandomTickManager;
@@ -19,7 +20,7 @@ public class BlockUpdateFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:blockupdate");
+    public @NotNull Key key() {
+        return Key.key("vri:blockupdate");
     }
 }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlockBehaviour.java
@@ -1,11 +1,11 @@
 package net.minestom.vanilla.blocks;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
-import net.minestom.server.utils.NamespaceID;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Objects;
@@ -17,12 +17,12 @@ public abstract class VanillaBlockBehaviour implements BlockHandler {
 
     protected final @NotNull VanillaBlocks.BlockContext context;
     protected final short baseBlock;
-    protected final @NotNull NamespaceID namespaceID;
+    protected final @NotNull Key key;
 
     protected VanillaBlockBehaviour(@NotNull VanillaBlocks.BlockContext context) {
         this.context = context;
         this.baseBlock = context.stateId();
-        this.namespaceID = Objects.requireNonNull(Block.fromStateId(context.stateId())).namespace();
+        this.key = Objects.requireNonNull(Block.fromStateId(context.stateId())).key();
     }
 
     /**
@@ -38,8 +38,8 @@ public abstract class VanillaBlockBehaviour implements BlockHandler {
     }
 
     @Override
-    public @NotNull NamespaceID getNamespaceId() {
-        return namespaceID;
+    public @NotNull Key getKey() {
+        return key;
     }
 
     public interface VanillaPlacement {

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlockLoot.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlockLoot.java
@@ -17,7 +17,10 @@ import net.minestom.vanilla.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
 import java.util.function.Consumer;
 import java.util.random.RandomGenerator;
 
@@ -27,7 +30,7 @@ public record VanillaBlockLoot(VanillaReimplementation vri, Datapack datapack) {
     }
 
     public void spawnLoot(@NotNull PlayerBlockBreakEvent event) {
-        String blockName = event.getBlock().namespace().value();
+        String blockName = event.getBlock().key().value();
         datapack.namespacedData().forEach((namespace, data) -> {
             FileSystem<LootTable> blocks = data.loot_tables().folder("blocks");
             var lootTable = blocks.file(blockName + ".json");
@@ -35,7 +38,7 @@ public record VanillaBlockLoot(VanillaReimplementation vri, Datapack datapack) {
 
             Block blockState = event.getBlock();
             Point origin = event.getBlockPosition();
-            ItemStack tool = event.getPlayer().getInventory().getItemInMainHand();
+            ItemStack tool = event.getPlayer().getItemInMainHand();
             Player entity = event.getPlayer();
             Block blockEntity = blockState.registry().blockEntity() == null ? null : blockState;
             Random random = vri.random(entity);

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
@@ -16,7 +16,6 @@ import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.blocks.behaviours.*;
 import net.minestom.vanilla.blocks.behaviours.oxidisable.OxidatableBlockBehaviour;
 import net.minestom.vanilla.blocks.behaviours.oxidisable.WaxedBlockBehaviour;
-import net.minestom.vanilla.blocks.behaviours.recipe.CampfireBehaviour;
 import net.minestom.vanilla.blocks.behaviours.recipe.*;
 import net.minestom.vanilla.blockupdatesystem.BlockUpdatable;
 import net.minestom.vanilla.blockupdatesystem.BlockUpdateManager;
@@ -138,8 +137,8 @@ public enum VanillaBlocks {
     BLAST_FURNACE(Block.BLAST_FURNACE, BlastingFurnaceBehaviour::new),
 
     STONE_CUTTER(Block.STONECUTTER, StonecutterBehaviour::new),
-    CAMPFIRE(Block.CAMPFIRE, CampfireBehaviour::new),
-    SOUL_CAMPFIRE(Block.SOUL_CAMPFIRE, CampfireBehaviour::new),
+//    CAMPFIRE(Block.CAMPFIRE, CampfireBehaviour::new), // TODO
+//    SOUL_CAMPFIRE(Block.SOUL_CAMPFIRE, CampfireBehaviour::new), // TODO
     SMITHING_TABLE(Block.SMITHING_TABLE, SmithingTableBehaviour::new),
 
     // Start of cakes

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocks.java
@@ -137,8 +137,8 @@ public enum VanillaBlocks {
     BLAST_FURNACE(Block.BLAST_FURNACE, BlastingFurnaceBehaviour::new),
 
     STONE_CUTTER(Block.STONECUTTER, StonecutterBehaviour::new),
-//    CAMPFIRE(Block.CAMPFIRE, CampfireBehaviour::new), // TODO
-//    SOUL_CAMPFIRE(Block.SOUL_CAMPFIRE, CampfireBehaviour::new), // TODO
+    CAMPFIRE(Block.CAMPFIRE, CampfireBehaviour::new),
+    SOUL_CAMPFIRE(Block.SOUL_CAMPFIRE, CampfireBehaviour::new),
     SMITHING_TABLE(Block.SMITHING_TABLE, SmithingTableBehaviour::new),
 
     // Start of cakes

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocksFeature.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/VanillaBlocksFeature.java
@@ -1,10 +1,10 @@
 package net.minestom.vanilla.blocks;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.player.PlayerBlockPlaceEvent;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.BlockUpdateFeature;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.datapack.DatapackLoadingFeature;
@@ -60,8 +60,8 @@ public class VanillaBlocksFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:blocks");
+    public @NotNull Key key() {
+        return Key.key("vri:blocks");
     }
 
     @Override

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/BedBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/BedBlockBehaviour.java
@@ -50,21 +50,25 @@ public class BedBlockBehaviour extends VanillaBlockBehaviour {
         Block blockAtPotentialBedHead = instance.getBlock(bedHeadPosition);
 
         if (isReplaceable(blockAtPotentialBedHead)) {
-            placeBed(instance, bedBlock, pos, bedHeadPosition, playerDirection);
+            Block foot = placeBed(instance, bedBlock, bedHeadPosition, playerDirection);
+            placement.blockToPlace(foot);
+        } else {
+            placement.blockToPlace(placement.instance().getBlock(placement.position()));
         }
+
     }
 
     private boolean isReplaceable(Block blockAtPosition) {
         return blockAtPosition.isAir() || blockAtPosition.isLiquid();
     }
 
-    private void placeBed(Instance instance, Block bedBlock, Point footPosition, Point headPosition, Direction facing) {
+    private Block placeBed(Instance instance, Block bedBlock, Point headPosition, Direction facing) {
         Block correctFacing = bedBlock.withProperty("facing", facing.name().toLowerCase());
 
         Block footBlock = correctFacing.withProperty("part", "foot");
-        Block headBlock = correctFacing.withProperty("part", "head");
-        instance.setBlock(footPosition, footBlock);
+        Block headBlock = correctFacing.withProperty("part", "head").withHandler(new BedBlockBehaviour(this.context));
         instance.setBlock(headPosition, headBlock);
+        return footBlock;
     }
 
     @Override
@@ -118,16 +122,14 @@ public class BedBlockBehaviour extends VanillaBlockBehaviour {
         Block block = destroy.getBlock();
         Point pos = destroy.getBlockPosition();
 
-        System.out.println(block.name());
-
-        boolean isFoot = "foot".equals(block.getProperty("part"));
+        boolean isHead = "head".equals(block.getProperty("part"));
         Direction facing = Direction.valueOf(block.getProperty("facing").toUpperCase());
 
-        if (isFoot) {
+        if (isHead) {
             facing = facing.opposite();
         }
 
-        Point otherPartPosition = pos.add(facing.normalX(), facing.normalY(), facing.normalZ()); // TODO: Investigate why direction is wrong
+        Point otherPartPosition = pos.add(facing.normalX(), facing.normalY(), facing.normalZ());
         instance.setBlock(pos, Block.AIR);
         instance.setBlock(otherPartPosition, Block.AIR);
     }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/BedBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/BedBlockBehaviour.java
@@ -2,7 +2,7 @@ package net.minestom.vanilla.blocks.behaviours;
 
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.entity.Entity;
+import net.minestom.server.entity.EntityPose;
 import net.minestom.server.entity.Player;
 import net.minestom.server.entity.metadata.PlayerMeta;
 import net.minestom.server.instance.Instance;
@@ -89,7 +89,7 @@ public class BedBlockBehaviour extends VanillaBlockBehaviour {
             // Make player sleep
             PlayerMeta meta = player.getPlayerMeta();
             meta.setBedInWhichSleepingPosition(pos);
-            meta.setPose(Entity.Pose.SLEEPING);
+            meta.setPose(EntityPose.SLEEPING);
 
             // Schedule player getting out of bed
             MinecraftServer.getSchedulerManager().buildTask(() -> {
@@ -98,7 +98,7 @@ public class BedBlockBehaviour extends VanillaBlockBehaviour {
                         }
 
                         meta.setBedInWhichSleepingPosition(null);
-                        meta.setPose(Entity.Pose.STANDING);
+                        meta.setPose(EntityPose.STANDING);
                     })
                     .delay(101, TimeUnit.SERVER_TICK)
                     .schedule();

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/FireBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/FireBlockBehaviour.java
@@ -6,7 +6,6 @@ import net.minestom.server.entity.LivingEntity;
 import net.minestom.server.entity.damage.DamageType;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.time.TimeUnit;
 import net.minestom.vanilla.blocks.VanillaBlockBehaviour;
 import net.minestom.vanilla.blocks.VanillaBlocks;
 import net.minestom.vanilla.system.NetherPortal;

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/JukeboxBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/JukeboxBlockBehaviour.java
@@ -4,14 +4,15 @@ import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
-import net.minestom.server.effects.Effects;
 import net.minestom.server.entity.ItemEntity;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.tag.Tag;
+import net.minestom.server.worldevent.WorldEvent;
 import net.minestom.vanilla.blocks.VanillaBlockBehaviour;
 import net.minestom.vanilla.blocks.VanillaBlocks;
 import net.minestom.vanilla.inventory.InventoryManipulation;
@@ -28,7 +29,7 @@ import java.util.Random;
  */
 public class JukeboxBlockBehaviour extends VanillaBlockBehaviour {
 
-    public static final Tag<ItemStack> DISC_KEY = Tag.ItemStack("minestom:jokebox_disc");
+    public static final Tag<ItemStack> DISC_KEY = Tag.ItemStack("minestom:jukebox_disc");
 
     public JukeboxBlockBehaviour(@NotNull VanillaBlocks.BlockContext context) {
         super(context);
@@ -61,11 +62,11 @@ public class JukeboxBlockBehaviour extends VanillaBlockBehaviour {
     @Override
     public boolean onInteract(@NotNull Interaction interaction) {
         Player player = interaction.getPlayer();
-        Player.Hand hand = interaction.getHand();
+        PlayerHand hand = interaction.getHand();
         Instance instance = interaction.getInstance();
         Block block = interaction.getBlock();
         Point pos = interaction.getBlockPosition();
-        ItemStack heldItem = player.getInventory().getItemInMainHand();
+        ItemStack heldItem = player.getItemInMainHand();
 
         ItemStack stack = this.getDisc(block);
 
@@ -92,7 +93,7 @@ public class JukeboxBlockBehaviour extends VanillaBlockBehaviour {
                 .filter(player1 -> player1.getDistance(pos) < 64)
                 .forEach(player1 ->
                         player1.playEffect(
-                                Effects.PLAY_RECORD,
+                                WorldEvent.SOUND_PLAY_JUKEBOX_SONG,
                                 pos.blockX(),
                                 pos.blockY(),
                                 pos.blockZ(),
@@ -169,7 +170,7 @@ public class JukeboxBlockBehaviour extends VanillaBlockBehaviour {
         instance.getPlayers().forEach(playerInInstance -> {
             // stop playback
             playerInInstance.playEffect(
-                    Effects.PLAY_RECORD,
+                    WorldEvent.SOUND_STOP_JUKEBOX_SONG,
                     pos.blockX(),
                     pos.blockY(),
                     pos.blockZ(),

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/NetherPortalBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/NetherPortalBlockBehaviour.java
@@ -15,10 +15,10 @@ import net.minestom.vanilla.blocks.VanillaBlocks;
 import net.minestom.vanilla.blockupdatesystem.BlockUpdatable;
 import net.minestom.vanilla.blockupdatesystem.BlockUpdateInfo;
 import net.minestom.vanilla.dimensions.VanillaDimensionTypes;
+import net.minestom.vanilla.system.NetherPortal;
 import net.minestom.vanilla.system.nether.EntityEnterNetherPortalEvent;
 import net.minestom.vanilla.system.nether.NetherPortalTeleportEvent;
 import net.minestom.vanilla.system.nether.NetherPortalUpdateEvent;
-import net.minestom.vanilla.system.NetherPortal;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/TNTBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/TNTBlockBehaviour.java
@@ -6,9 +6,9 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.Material;
 import net.minestom.vanilla.VanillaRegistry;
 import net.minestom.vanilla.blocks.VanillaBlockBehaviour;
@@ -35,10 +35,9 @@ public class TNTBlockBehaviour extends VanillaBlockBehaviour {
     public boolean onInteract(@NotNull Interaction interaction) {
         Point blockPosition = interaction.getBlockPosition();
         Player player = interaction.getPlayer();
-        Player.Hand hand = interaction.getHand();
-        PlayerInventory inventory = player.getInventory();
+        PlayerHand hand = interaction.getHand();
 
-        if (inventory.getItemInHand(hand).material() != Material.FLINT_AND_STEEL) {
+        if (player.getItemInHand(hand).material() != Material.FLINT_AND_STEEL) {
             return true;
         }
 

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockInventory.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockInventory.java
@@ -1,21 +1,15 @@
 package net.minestom.vanilla.blocks.behaviours.chestlike;
 
 import net.kyori.adventure.text.Component;
-import net.minestom.server.coordinate.BlockVec;
 import net.minestom.server.coordinate.Point;
-import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.Instance;
-import net.minestom.server.instance.block.Block;
 import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.InventoryType;
 import net.minestom.server.item.ItemStack;
-import net.minestom.server.tag.Tag;
 import net.minestom.vanilla.blocks.behaviours.InventoryBlockBehaviour;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockInventory.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockInventory.java
@@ -9,7 +9,6 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.vanilla.blocks.behaviours.InventoryBlockBehaviour;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -17,7 +16,6 @@ import java.util.concurrent.ConcurrentHashMap;
 public class BlockInventory extends Inventory {
     private static final Map<Point, BlockInventory> BLOCK_INVENTORY_MAP = new ConcurrentHashMap<>();
 
-    protected final ItemStack[] items;
     protected final Instance instance;
     protected final Point pos;
 
@@ -29,12 +27,10 @@ public class BlockInventory extends Inventory {
 
         // Set items
         List<ItemStack> itemsList = instance.getBlock(pos).getTag(InventoryBlockBehaviour.TAG_ITEMS);
-        if (itemsList == null) {
-            ItemStack[] newItems = new ItemStack[inventoryType.getSize()];
-            Arrays.fill(newItems, ItemStack.AIR);
-            this.items = newItems;
-        } else {
-            this.items = itemsList.toArray(ItemStack[]::new);
+        if (itemsList != null) {
+            for (int i = 0; i < itemsList.size(); i++) {
+                this.itemStacks[i] = itemsList.get(i);
+            }
         }
     }
 
@@ -59,33 +55,12 @@ public class BlockInventory extends Inventory {
             return List.of();
         }
         BLOCK_INVENTORY_MAP.remove(pos);
-        return inv.itemStacks();
-    }
-
-    @Override
-    public @NotNull ItemStack getItemStack(int slot) {
-        ItemStack item = items[slot];
-
-        if (item == null) {
-            return ItemStack.AIR;
-        }
-
-        return item;
+        return List.of(inv.itemStacks);
     }
 
     @Override
     public void setItemStack(int slot, @NotNull ItemStack itemStack) {
-        items[slot] = itemStack;
-        instance.setBlock(pos, instance.getBlock(pos).withTag(InventoryBlockBehaviour.TAG_ITEMS, List.of(items)));
-    }
-
-    @Override
-    @Deprecated
-    public ItemStack @NotNull [] getItemStacks() {
-        return itemStacks().toArray(ItemStack[]::new);
-    }
-
-    public @NotNull List<ItemStack> itemStacks() {
-        return List.of(items);
+        super.setItemStack(slot, itemStack);
+        instance.setBlock(pos, instance.getBlock(pos).withTag(InventoryBlockBehaviour.TAG_ITEMS, List.of(itemStacks)));
     }
 }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockItems.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/BlockItems.java
@@ -1,18 +1,14 @@
 package net.minestom.vanilla.blocks.behaviours.chestlike;
 
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import net.minestom.server.item.Material;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.item.ItemStack;
+import net.minestom.server.tag.Tag;
 import net.minestom.vanilla.tag.Tags;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnmodifiableView;
 
-import net.minestom.server.instance.block.Block;
-import net.minestom.server.item.ItemStack;
-import net.minestom.server.tag.Tag;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * The key difference between BlockItems and BlockInventory is that BlockItems

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/DoubleChestInventory.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/chestlike/DoubleChestInventory.java
@@ -44,7 +44,8 @@ public class DoubleChestInventory extends Inventory {
 
     public List<ItemStack> itemStacks() {
         return Stream.of(left, right)
-                .map(BlockInventory::itemStacks)
+                .map(BlockInventory::getItemStacks)
+                .map(List::of)
                 .flatMap(Collection::stream)
                 .toList();
     }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/OxidatableBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/OxidatableBlockBehaviour.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.blocks.behaviours.oxidisable;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -123,15 +124,15 @@ public class OxidatableBlockBehaviour extends WaxableBlockBehaviour implements R
 
     @Override
     public boolean onInteract(@NotNull Interaction interaction) {
-        Player.Hand hand = interaction.getHand();
+        PlayerHand hand = interaction.getHand();
         Player player = interaction.getPlayer();
         Block interactionBlock = interaction.getBlock();
 
-        ItemStack item = player.getInventory().getItemInHand(hand);
+        ItemStack item = player.getItemInHand(hand);
         Material material = item.material();
 
         if (interactionBlock.stateId() != previous
-                && material.namespace().value().toLowerCase().contains("_axe")) { // TODO: Better way to check if it's an axe
+                && material.key().value().toLowerCase().contains("_axe")) { // TODO: Better way to check if it's an axe
             Block previousBlock = Block.fromStateId(previous);
             Objects.requireNonNull(previousBlock, "Block with state id " + previous + " was not found");
             interaction.getInstance().setBlock(interaction.getBlockPosition(), previousBlock);

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/WaxableBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/WaxableBlockBehaviour.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.blocks.behaviours.oxidisable;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -20,10 +21,10 @@ public abstract class WaxableBlockBehaviour extends VanillaBlockBehaviour {
 
     @Override
     public boolean onInteract(@NotNull Interaction interaction) {
-        Player.Hand hand = interaction.getHand();
+        PlayerHand hand = interaction.getHand();
         Player player = interaction.getPlayer();
 
-        ItemStack item = player.getInventory().getItemInHand(hand);
+        ItemStack item = player.getItemInHand(hand);
         Material material = item.material();
 
         if (Material.HONEYCOMB.equals(material)) {

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/WaxedBlockBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/oxidisable/WaxedBlockBehaviour.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.blocks.behaviours.oxidisable;
 
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
@@ -20,14 +21,13 @@ public class WaxedBlockBehaviour extends OxidatedBlockBehaviour {
 
     @Override
     public boolean onInteract(@NotNull Interaction interaction) {
-        Player.Hand hand = interaction.getHand();
+        PlayerHand hand = interaction.getHand();
         Player player = interaction.getPlayer();
-        Block interactionBlock = interaction.getBlock();
 
-        ItemStack item = player.getInventory().getItemInHand(hand);
+        ItemStack item = player.getItemInHand(hand);
         Material material = item.material();
 
-        if (material.namespace().value().toLowerCase().contains("_axe")) { // TODO: Better way to check if it's an axe
+        if (material.key().value().toLowerCase().contains("_axe")) { // TODO: Better way to check if it's an axe
             Block previousBlock = Block.fromStateId(unWaxed);
             Objects.requireNonNull(previousBlock, "Previous block with state id " + unWaxed + " was not found");
             interaction.getInstance().setBlock(interaction.getBlockPosition(), previousBlock);

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/recipe/CampfireBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/recipe/CampfireBehaviour.java
@@ -64,7 +64,6 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
 
     @Override
     public boolean onInteract(@NotNull BlockHandler.Interaction interaction) {
-        // TODO: onInteract is never called when right-clicking the campfire while holding food. Instead, the eating animation plays.
         Instance instance = interaction.getInstance();
         Point pos = interaction.getBlockPosition();
         Block block = interaction.getBlock();
@@ -200,6 +199,14 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
     private Material getRecipeResult(Recipe recipe) {
         RecipeDisplay d = recipe.createRecipeDisplays().getFirst();
         if (d instanceof RecipeDisplay.Furnace f) {
+            return getMaterialFromSlotDisplay(f.result());
+        }
+        return null;
+    }
+
+    private Material getRecipeInput(Recipe recipe) {
+        RecipeDisplay d = recipe.createRecipeDisplays().getFirst();
+        if (d instanceof RecipeDisplay.Furnace f) {
             return getMaterialFromSlotDisplay(f.ingredient());
         }
         return null;
@@ -219,6 +226,6 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
         return recipeManager
                 .getRecipes().stream()
                 .filter(r -> r.recipeBookCategory() == RecipeBookCategory.CAMPFIRE)
-                .filter(recipe -> input.material().equals(getRecipeResult(recipe))).findFirst();
+                .filter(recipe -> input.material().equals(getRecipeInput(recipe))).findFirst();
     }
 }

--- a/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/recipe/CampfireBehaviour.java
+++ b/blocks/src/main/java/net/minestom/vanilla/blocks/behaviours/recipe/CampfireBehaviour.java
@@ -1,19 +1,5 @@
 package net.minestom.vanilla.blocks.behaviours.recipe;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.ListIterator;
-import java.util.Optional;
-import java.util.OptionalInt;
-import java.util.Random;
-import java.util.stream.IntStream;
-
-import net.minestom.server.recipe.RecipeType;
-import net.minestom.vanilla.logging.Logger;
-import org.jetbrains.annotations.NotNull;
-
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.ItemEntity;
@@ -23,14 +9,19 @@ import net.minestom.server.instance.block.Block;
 import net.minestom.server.instance.block.BlockHandler;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.recipe.CampfireCookingRecipe;
-import net.minestom.server.recipe.RecipeManager;
+import net.minestom.server.recipe.*;
+import net.minestom.server.recipe.display.RecipeDisplay;
+import net.minestom.server.recipe.display.SlotDisplay;
 import net.minestom.server.tag.Tag;
 import net.minestom.vanilla.blocks.VanillaBlockBehaviour;
 import net.minestom.vanilla.blocks.VanillaBlocks;
 import net.minestom.vanilla.blocks.behaviours.chestlike.BlockItems;
 import net.minestom.vanilla.inventory.InventoryManipulation;
 import net.minestom.vanilla.tag.Tags.Blocks.Campfire;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.stream.IntStream;
 
 public class CampfireBehaviour extends VanillaBlockBehaviour {
 
@@ -57,31 +48,29 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
      * Appends an id to the first available slot in the campfire.
      * @return the index of the slot the id was appended to.
      */
-    public int appendItem(BlockItems items, @NotNull CampfireCookingRecipe recipe) {
+    public int appendItem(BlockItems items, @NotNull Material material) {
         OptionalInt freeSlot = findFirstFreeSlot(items.itemStacks());
 
         if (freeSlot.isEmpty())
             throw new IllegalArgumentException("Campfire doesn't have free slot for appending an id in CampfireBehaviour#appendItem");
 
-        List<ItemStack> ingredients = recipe.getIngredient().items();
-
-        if (ingredients == null || ingredients.size() != 1)
-            throw new IllegalArgumentException("CampfireCookingRecipe has invalid ingredients in CampfireBehaviour#appendItem.");
+        ItemStack ingredient = ItemStack.of(material);
 
         int index = freeSlot.getAsInt();
-        items.set(index, ingredients.get(0));
+        items.set(index, ingredient);
 
         return index;
     }
 
     @Override
     public boolean onInteract(@NotNull BlockHandler.Interaction interaction) {
+        // TODO: onInteract is never called when right-clicking the campfire while holding food. Instead, the eating animation plays.
         Instance instance = interaction.getInstance();
         Point pos = interaction.getBlockPosition();
         Block block = interaction.getBlock();
         Player player = interaction.getPlayer();
         ItemStack input = player.getItemInHand(interaction.getHand());
-        Optional<CampfireCookingRecipe> recipeOptional = findCampfireCookingRecipe(input);
+        Optional<Recipe> recipeOptional = findCampfireCookingRecipe(input);
 
         if (recipeOptional.isEmpty())
             return true;
@@ -95,9 +84,12 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
         if (itemNotConsumed)
             return true;
 
-        CampfireCookingRecipe recipe = recipeOptional.get();
-        int index = appendItem(items, recipe);
-        block = withCookingProgress(block, index, recipe.getCookingTime());
+        Recipe recipe = recipeOptional.get();
+        if (!(recipe.createRecipeDisplays().getFirst() instanceof RecipeDisplay.Furnace furnaceRecipe)) return false;
+        Material material = getMaterialFromSlotDisplay(furnaceRecipe.ingredient());
+        if (material == null) return false;
+        int index = appendItem(items, material);
+        block = withCookingProgress(block, index, furnaceRecipe.duration());
         instance.setBlock(pos, items.apply(block));
         return false;
     }
@@ -185,10 +177,14 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
     }
 
     private void endCampfireCookingProgress(Instance instance, Point pos, ItemStack input) {
-        Optional<CampfireCookingRecipe> recipeOptional = findCampfireCookingRecipe(input);
+        Optional<Recipe> recipeOptional = findCampfireCookingRecipe(input);
         if (recipeOptional.isEmpty())
             throw new IllegalArgumentException("Cannot end campfire cooking progress because input recipe doesn't found");
-        dropItem(instance, pos, recipeOptional.get().getResult());
+        Material material = getRecipeResult(recipeOptional.get());
+        if (material == null) {
+            return;
+        }
+        dropItem(instance, pos, ItemStack.of(material));
     }
 
     private void dropItem(Instance instance, Point pos, ItemStack item) {
@@ -201,21 +197,28 @@ public class CampfireBehaviour extends VanillaBlockBehaviour {
         return IntStream.range(0, items.size()).filter(index -> items.get(index).isAir()).findFirst();
     }
 
-    private Optional<CampfireCookingRecipe> findCampfireCookingRecipe(ItemStack input) {
+    private Material getRecipeResult(Recipe recipe) {
+        RecipeDisplay d = recipe.createRecipeDisplays().getFirst();
+        if (d instanceof RecipeDisplay.Furnace f) {
+            return getMaterialFromSlotDisplay(f.ingredient());
+        }
+        return null;
+    }
+
+    private Material getMaterialFromSlotDisplay(SlotDisplay slotDisplay) {
+        return switch (slotDisplay) {
+            case SlotDisplay.Item i -> i.material();
+            case SlotDisplay.ItemStack i -> i.itemStack().material();
+            default -> null;
+        };
+    }
+
+    private Optional<Recipe> findCampfireCookingRecipe(ItemStack input) {
         if (input == null)
             return Optional.empty();
         return recipeManager
                 .getRecipes().stream()
-                .filter(recipe -> recipe.type() == RecipeType.CAMPFIRE_COOKING)
-                .map(CampfireCookingRecipe.class::cast)
-                .filter(recipe -> {
-                    List<ItemStack> items = recipe.getIngredient().items();
-                    if (items == null)
-                        return false;
-                    if (items.size() != 1)
-                        return false;
-                    return items.get(0).material().equals(input.material());
-                }).findFirst();
+                .filter(r -> r.recipeBookCategory() == RecipeBookCategory.CAMPFIRE)
+                .filter(recipe -> input.material().equals(getRecipeResult(recipe))).findFirst();
     }
-
 }

--- a/commands/src/main/java/net/minestom/vanilla/commands/ForceloadCommand.java
+++ b/commands/src/main/java/net/minestom/vanilla/commands/ForceloadCommand.java
@@ -4,10 +4,10 @@ import net.minestom.server.command.CommandSender;
 import net.minestom.server.command.builder.Command;
 import net.minestom.server.command.builder.CommandContext;
 import net.minestom.server.command.builder.arguments.ArgumentType;
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.Instance;
-import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.utils.location.RelativeVec;
 import net.minestom.vanilla.instancemeta.tickets.TicketManager;
 import net.minestom.vanilla.instancemeta.tickets.TicketUtils;
@@ -24,7 +24,6 @@ import java.util.List;
  * BE_EE_OP_Level: 0
  * MP_Only: false
  */
-@SuppressWarnings("UnstableApiUsage")
 public class ForceloadCommand extends Command {
 
     public ForceloadCommand() {
@@ -60,7 +59,7 @@ public class ForceloadCommand extends Command {
     }
 
     private void addForceLoad(Instance instance, int chunkX, int chunkZ) {
-        addForceLoad(instance, ChunkUtils.getChunkIndex(chunkX, chunkZ));
+        addForceLoad(instance, CoordConversion.chunkIndex(chunkX, chunkZ));
     }
 
     private void addForceLoad(Instance instance, long chunkIndex) {
@@ -69,7 +68,7 @@ public class ForceloadCommand extends Command {
     }
 
     private void removeForceLoad(Instance instance, int chunkX, int chunkZ) {
-        removeForceLoad(instance, ChunkUtils.getChunkIndex(chunkX, chunkZ));
+        removeForceLoad(instance, CoordConversion.chunkIndex(chunkX, chunkZ));
     }
 
     private void removeForceLoad(Instance instance, long chunkIndex) {
@@ -87,8 +86,8 @@ public class ForceloadCommand extends Command {
         Vec position = fromVec.from(player.getPosition());
 
         // Get chunk position
-        int chunkX = ChunkUtils.getChunkCoordinate(position.x());
-        int chunkZ = ChunkUtils.getChunkCoordinate(position.z());
+        int chunkX = CoordConversion.globalToChunk(position.x());
+        int chunkZ = CoordConversion.globalToChunk(position.z());
 
         // Add the force load
         Instance instance = player.getInstance();
@@ -115,8 +114,8 @@ public class ForceloadCommand extends Command {
         for (int offX = startX; offX < endX; offX += 16) {
             for (int offZ = startZ; offZ < endZ; offZ += 16) {
                 // Get chunk position
-                int chunkX = ChunkUtils.getChunkCoordinate(offX);
-                int chunkZ = ChunkUtils.getChunkCoordinate(offZ);
+                int chunkX = CoordConversion.globalToChunk(offX);
+                int chunkZ = CoordConversion.globalToChunk(offZ);
                 removeForceLoad(instance, chunkX, chunkZ);
             }
         }
@@ -131,8 +130,8 @@ public class ForceloadCommand extends Command {
         Vec position = fromVec.from(player.getPosition());
 
         // Get chunk position
-        int chunkX = ChunkUtils.getChunkCoordinate(position.x());
-        int chunkZ = ChunkUtils.getChunkCoordinate(position.z());
+        int chunkX = CoordConversion.globalToChunk(position.x());
+        int chunkZ = CoordConversion.globalToChunk(position.z());
 
         // Remove force load
         Instance instance = player.getInstance();
@@ -160,8 +159,8 @@ public class ForceloadCommand extends Command {
         for (int offX = minX; offX <= maxX; offX += 16) {
             for (int offZ = minZ; offZ <= maxZ; offZ += 16) {
                 // Get chunk position
-                int chunkX = ChunkUtils.getChunkCoordinate(offX);
-                int chunkZ = ChunkUtils.getChunkCoordinate(offZ);
+                int chunkX = CoordConversion.globalToChunk(offX);
+                int chunkZ = CoordConversion.globalToChunk(offZ);
 
                 // Remove the force load
                 removeForceLoad(instance, chunkX, chunkZ);

--- a/commands/src/main/java/net/minestom/vanilla/commands/VanillaCommandsFeature.java
+++ b/commands/src/main/java/net/minestom/vanilla/commands/VanillaCommandsFeature.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.commands;
 
-import net.minestom.server.utils.NamespaceID;
+
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.instancemeta.InstanceMetaFeature;
 import org.jetbrains.annotations.NotNull;
@@ -15,8 +16,8 @@ public class VanillaCommandsFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:commands");
+    public @NotNull Key key() {
+        return Key.key("vri:commands");
     }
 
     private static class Logic {

--- a/core/src/main/java/net/minestom/vanilla/VanillaReimplementation.java
+++ b/core/src/main/java/net/minestom/vanilla/VanillaReimplementation.java
@@ -1,12 +1,12 @@
 package net.minestom.vanilla;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.ServerProcess;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.tag.TagWritable;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.world.DimensionType;
 import net.minestom.vanilla.logging.StatusUpdater;
 import net.minestom.vanilla.utils.DependencySorting;
@@ -102,7 +102,7 @@ public interface VanillaReimplementation {
     /**
      * Creates and registers a vanilla instance.
      */
-    @NotNull Instance createInstance(@NotNull NamespaceID namespace, @NotNull DimensionType dimension);
+    @NotNull Instance createInstance(@NotNull Key namespace, @NotNull DimensionType dimension);
 
     /**
      * Gets a registered vanilla instance.
@@ -110,7 +110,7 @@ public interface VanillaReimplementation {
      * @param namespace the namespace of the instance
      * @return the instance, or null if not found
      */
-    @Nullable Instance getInstance(NamespaceID namespace);
+    @Nullable Instance getInstance(Key namespace);
 
     /**
      * Retrieves or generates a random object unique to the given object.
@@ -167,9 +167,9 @@ public interface VanillaReimplementation {
         }
 
         /**
-         * @return a unique {@link NamespaceID} for this feature
+         * @return a unique {@link Key} for this feature
          */
-        @NotNull NamespaceID namespaceId();
+        @NotNull Key key();
 
         /**
          * @return a unique {@link Class} for this feature

--- a/core/src/main/java/net/minestom/vanilla/dimensions/VanillaDimensionTypes.java
+++ b/core/src/main/java/net/minestom/vanilla/dimensions/VanillaDimensionTypes.java
@@ -1,11 +1,9 @@
 package net.minestom.vanilla.dimensions;
 
-import net.minestom.server.MinecraftServer;
+import net.kyori.adventure.key.Key;
 import net.minestom.server.registry.DynamicRegistry;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.world.DimensionType;
 
-import java.util.List;
 import java.util.Map;
 
 public class VanillaDimensionTypes {
@@ -13,9 +11,9 @@ public class VanillaDimensionTypes {
     public static final DimensionType OVERWORLD = DimensionType.builder()
             .build();
 
-    public static Map<DimensionType, NamespaceID> values() {
+    public static Map<DimensionType, Key> values() {
         return Map.of(
-                OVERWORLD, NamespaceID.from("vri:overworld")
+                OVERWORLD, Key.key("vri:overworld")
         );
     }
 

--- a/core/src/main/java/net/minestom/vanilla/events/BlastingFurnaceTickEvent.java
+++ b/core/src/main/java/net/minestom/vanilla/events/BlastingFurnaceTickEvent.java
@@ -1,7 +1,6 @@
 package net.minestom.vanilla.events;
 
 import net.minestom.server.coordinate.BlockVec;
-import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.InstanceEvent;

--- a/core/src/main/java/net/minestom/vanilla/events/FurnaceTickEvent.java
+++ b/core/src/main/java/net/minestom/vanilla/events/FurnaceTickEvent.java
@@ -1,7 +1,6 @@
 package net.minestom.vanilla.events;
 
 import net.minestom.server.coordinate.BlockVec;
-import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.InstanceEvent;

--- a/core/src/main/java/net/minestom/vanilla/events/SmokerTickEvent.java
+++ b/core/src/main/java/net/minestom/vanilla/events/SmokerTickEvent.java
@@ -1,7 +1,6 @@
 package net.minestom.vanilla.events;
 
 import net.minestom.server.coordinate.BlockVec;
-import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.InstanceEvent;

--- a/core/src/main/java/net/minestom/vanilla/files/LazyFileSystem.java
+++ b/core/src/main/java/net/minestom/vanilla/files/LazyFileSystem.java
@@ -2,7 +2,8 @@ package net.minestom.vanilla.files;
 
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**

--- a/core/src/main/java/net/minestom/vanilla/instance/VanillaExplosion.java
+++ b/core/src/main/java/net/minestom/vanilla/instance/VanillaExplosion.java
@@ -126,7 +126,7 @@ public class VanillaExplosion extends Explosion {
 //                            table = customBlock.getLootTable(lootTableManager);
 //                        }
 //                        if (table == null) {
-//                            table = lootTableManager.load(NamespaceID.from("blocks/" + block.name().toLowerCase()));
+//                            table = lootTableManager.load(Key.key("blocks/" + block.name().toLowerCase()));
 //                        }
 //                        List<ItemStack> output = table.generate(lootTableArguments);
 //                        for (ItemStack out : output) {

--- a/core/src/main/java/net/minestom/vanilla/inventory/InventoryManipulation.java
+++ b/core/src/main/java/net/minestom/vanilla/inventory/InventoryManipulation.java
@@ -1,19 +1,20 @@
 package net.minestom.vanilla.inventory;
 
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.Player;
-import net.minestom.server.item.ItemComponent;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.item.ItemStack;
 
 import java.util.Objects;
 
 public class InventoryManipulation {
-    public static void consumeItemIfNotCreative(Player player, ItemStack itemStack, Player.Hand hand) {
+    public static void consumeItemIfNotCreative(Player player, ItemStack itemStack, PlayerHand hand) {
         if (player.getGameMode() == GameMode.CREATIVE) {
             return;
         }
 
-        player.getInventory().setItemInHand(hand, itemStack);
+        player.setItemInHand(hand, itemStack);
     }
 
     /**
@@ -21,7 +22,7 @@ public class InventoryManipulation {
      *
      * @return true if there was enough items to consume, false otherwise.
      */
-    public static boolean consumeItemIfNotCreative(Player player, Player.Hand hand, int amount) {
+    public static boolean consumeItemIfNotCreative(Player player, PlayerHand hand, int amount) {
         if (player.getGameMode() == GameMode.CREATIVE) {
             return true;
         }
@@ -30,23 +31,23 @@ public class InventoryManipulation {
         item = item.withAmount(amt -> amt - amount);
         if (item.amount() == 0) item = ItemStack.AIR;
         if (item.amount() < 0) return false;
-        player.getInventory().setItemInHand(hand, item);
+        player.setItemInHand(hand, item);
         return true;
     }
 
-    public static void damageItemIfNotCreative(Player player, Player.Hand hand, int amount) {
+    public static void damageItemIfNotCreative(Player player, PlayerHand hand, int amount) {
         if (player.getGameMode() == GameMode.CREATIVE) {
             return;
         }
 
         ItemStack itemStack = player.getItemInHand(hand);
-        int damage = Objects.requireNonNullElse(itemStack.get(ItemComponent.DAMAGE), 0);
-        int maxDamage = Objects.requireNonNull(itemStack.material().registry().prototype().get(ItemComponent.MAX_DAMAGE));
-        ItemStack newItem = itemStack.with(ItemComponent.DAMAGE, damage + amount);
+        int damage = Objects.requireNonNullElse(itemStack.get(DataComponents.DAMAGE), 0);
+        int maxDamage = Objects.requireNonNull(itemStack.material().registry().prototype().get(DataComponents.MAX_DAMAGE));
+        ItemStack newItem = itemStack.with(DataComponents.DAMAGE, damage + amount);
         if (damage + amount >= maxDamage) {
             newItem = ItemStack.AIR;
             // TODO: Item Break Event
         }
-        player.getInventory().setItemInHand(hand, newItem);
+        player.setItemInHand(hand, newItem);
     }
 }

--- a/core/src/main/java/net/minestom/vanilla/system/NetherPortal.java
+++ b/core/src/main/java/net/minestom/vanilla/system/NetherPortal.java
@@ -1,18 +1,17 @@
 package net.minestom.vanilla.system;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
-import net.minestom.server.effects.Effects;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.network.packet.server.play.EffectPacket;
 import net.minestom.server.network.packet.server.play.ParticlePacket;
+import net.minestom.server.network.packet.server.play.WorldEventPacket;
 import net.minestom.server.particle.Particle;
-import net.minestom.server.utils.NamespaceID;
-import net.minestom.vanilla.dimensions.VanillaDimensionTypes;
+import net.minestom.server.worldevent.WorldEvent;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
@@ -112,8 +111,8 @@ public final class NetherPortal {
                     0.3f, 10
             );
 
-            EffectPacket effectPacket = new EffectPacket(
-                    Effects.BLOCK_BREAK.getId(),
+            WorldEventPacket effectPacket = new WorldEventPacket(
+                    WorldEvent.PARTICLES_DESTROY_BLOCK.id(),
                     pos,
                     Block.NETHER_PORTAL.id(),
                     false
@@ -128,7 +127,7 @@ public final class NetherPortal {
     }
 
     public boolean tryFillFrame(Instance instance) {
-        if (instance.getDimensionType().namespace().equals(NamespaceID.from("the_end"))) {
+        if (instance.getDimensionType().key().equals(Key.key("the_end"))) {
             return false;
         }
 

--- a/core/src/main/java/net/minestom/vanilla/tag/Tags.java
+++ b/core/src/main/java/net/minestom/vanilla/tag/Tags.java
@@ -1,14 +1,13 @@
 package net.minestom.vanilla.tag;
 
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.nbt.*;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -38,9 +37,9 @@ public interface Tags {
         }
 
         interface Potion {
-            Tag<NamespaceID> POTION = TAG.path("Potion")
+            Tag<Key> POTION = TAG.path("Potion")
                     .map(nbt -> nbt instanceof StringBinaryTag nbts ?
-                            NamespaceID.from(nbts.value()) : NamespaceID.from("minecraft:empty"),
+                            Key.key(nbts.value()) : Key.key("minecraft:empty"),
                             nbt -> StringBinaryTag.stringBinaryTag(nbt.toString()));
         }
     }
@@ -51,7 +50,7 @@ public interface Tags {
                     .map(nbt -> nbt instanceof CompoundBinaryTag compound ? compound : CompoundBinaryTag.empty(), nbt -> nbt)
                     .list()
                     .map(nbtList -> nbtList.stream()
-                                    .map(nbt -> ItemStack.of(Material.fromNamespaceId(nbt.getString("id"))))
+                                    .map(nbt -> ItemStack.of(Material.fromKey(nbt.getString("id"))))
                                     .collect(Collectors.toList()),
                             items -> IntStream.range(0, items.size())
                                     .mapToObj(slot -> CompoundBinaryTag.from(Map.of(
@@ -71,7 +70,7 @@ public interface Tags {
 
             // The last fuel item that was used. Null if this furnace is not currently burning
             Tag<Material> LAST_COOKED_ITEM = Tag.String("vri:furnace:last_cooked_item")
-                    .map(Material::fromNamespaceId, mat -> mat.namespace().toString())
+                    .map(Material::fromKey, mat -> mat.key().toString())
                     .defaultValue(Material.AIR);
 
             // The number of ticks that the furnace has been cooking for

--- a/core/src/main/java/net/minestom/vanilla/utils/DependencySorting.java
+++ b/core/src/main/java/net/minestom/vanilla/utils/DependencySorting.java
@@ -1,6 +1,9 @@
 package net.minestom.vanilla.utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 public class DependencySorting {
 

--- a/core/src/main/java/net/minestom/vanilla/utils/MinestomUtils.java
+++ b/core/src/main/java/net/minestom/vanilla/utils/MinestomUtils.java
@@ -1,15 +1,15 @@
 package net.minestom.vanilla.utils;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.MinecraftServer;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.item.ItemComponent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.item.component.EnchantmentList;
 import net.minestom.server.item.enchant.Enchantment;
 import net.minestom.server.registry.DynamicRegistry;
-import net.minestom.server.utils.NamespaceID;
 
 public class MinestomUtils {
 
@@ -23,10 +23,10 @@ public class MinestomUtils {
         EntityType.values();
     }
 
-    public static int getEnchantLevel(ItemStack itemStack, NamespaceID enchantment, int defaultValue) {
+    public static int getEnchantLevel(ItemStack itemStack, Key enchantment, int defaultValue) {
         DynamicRegistry.Key<Enchantment> enchant = getEnchantKey(enchantment);
         if (enchant == null) return defaultValue;
-        EnchantmentList enchants = itemStack.get(ItemComponent.ENCHANTMENTS);
+        EnchantmentList enchants = itemStack.get(DataComponents.ENCHANTMENTS);
         if (enchants == null) return defaultValue;
         if (!enchants.has(enchant)) return defaultValue;
         return enchants.level(enchant);
@@ -36,7 +36,7 @@ public class MinestomUtils {
         return MinecraftServer.getEnchantmentRegistry().getKey(enchantment);
     }
 
-    public static DynamicRegistry.Key<Enchantment> getEnchantKey(NamespaceID enchantment) {
+    public static DynamicRegistry.Key<Enchantment> getEnchantKey(Key enchantment) {
         int id = MinecraftServer.getEnchantmentRegistry().getId(enchantment);
         return MinecraftServer.getEnchantmentRegistry().getKey(id);
     }

--- a/core/src/test/java/net/minestom/vanilla/files/FileSystemTests.java
+++ b/core/src/test/java/net/minestom/vanilla/files/FileSystemTests.java
@@ -3,7 +3,8 @@ package net.minestom.vanilla.files;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class FileSystemTests {
     @Test

--- a/crafting/build.gradle.kts
+++ b/crafting/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
     compileOnly(project(":core"))
     compileOnly(project(":datapack-loading"))
-    implementation("com.github.GoldenStack:window:${project.property("window_version")}")
+    implementation("net.goldenstack:window:${project.property("window_version")}")
 }

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingFeature.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingFeature.java
@@ -1,8 +1,8 @@
 package net.minestom.vanilla.crafting;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.crafting.smelting.BlastingInventoryRecipes;
 import net.minestom.vanilla.crafting.smelting.SmeltingInventoryRecipes;
@@ -30,11 +30,11 @@ public class CraftingFeature implements VanillaReimplementation.Feature {
             recipeFileSystem.files().stream().collect(Collectors.toMap(Function.identity(), recipeFileSystem::file)).forEach((id, recipe) -> {
                 var recipeManager = context.vri().process().recipe();
 
-                net.minestom.server.recipe.Recipe minestomRecipe = recipeConverter.convert(id, recipe, player -> true);
+                net.minestom.server.recipe.Recipe minestomRecipe = recipeConverter.convert(id, recipe);
                 if (minestomRecipe == null) {
                     return;
                 }
-                recipeManager.addRecipe(minestomRecipe);
+                recipeManager.addRecipe(minestomRecipe, player -> true);
             });
         });
 
@@ -61,8 +61,8 @@ public class CraftingFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:crafting");
+    public @NotNull Key key() {
+        return Key.key("vri:crafting");
     }
 
     @Override

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingInventoryRecipes.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.crafting;
 
-import dev.goldenstack.window.InventoryView;
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.InventoryView;
+import net.goldenstack.window.Views;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.inventory.InventoryClickEvent;
@@ -14,7 +14,10 @@ import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.recipe.Recipe;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 
 public record CraftingInventoryRecipes(Datapack datapack, VanillaReimplementation vri) {
 
@@ -23,9 +26,8 @@ public record CraftingInventoryRecipes(Datapack datapack, VanillaReimplementatio
 
         node.addListener(InventoryClickEvent.class, event -> {
             int slot = event.getSlot();
-            if (event.getInventory() == null) return;
-            Inventory inv = event.getInventory();
-            if (event.getInventory().getInventoryType() != InventoryType.CRAFTING) return;
+            if (!(event.getInventory() instanceof Inventory inv)) return;
+            if (inv.getInventoryType() != InventoryType.CRAFTING) return;
 
             var table = Views.CRAFTING_TABLE;
 

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingUtils.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/CraftingUtils.java
@@ -1,6 +1,6 @@
 package net.minestom.vanilla.crafting;
 
-import dev.goldenstack.window.InventoryView;
+import net.goldenstack.window.InventoryView;
 import net.kyori.adventure.key.Key;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.event.inventory.InventoryPreClickEvent;
@@ -8,7 +8,6 @@ import net.minestom.server.inventory.Inventory;
 import net.minestom.server.inventory.InventoryType;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.DatapackUtils;
 import net.minestom.vanilla.datapack.recipe.Recipe;
@@ -143,8 +142,8 @@ public record CraftingUtils(Datapack datapack) {
         if (ingredient instanceof Recipe.Ingredient.Tag tag) {
             return DatapackUtils.findTags(datapack, "item", tag.tag())
                     .stream()
-                    .map(NamespaceID::from)
-                    .map(Material::fromNamespaceId)
+                    .map(Key::key)
+                    .map(Material::fromKey)
                     .filter(Objects::nonNull)
                     .collect(Collectors.toUnmodifiableSet());
         }
@@ -183,15 +182,8 @@ public record CraftingUtils(Datapack datapack) {
         node.addListener(InventoryPreClickEvent.class, event -> {
             // for stacking items from an output slot
             int slot = event.getSlot();
-            Inventory inventory = event.getInventory();
-            if (inventory == null) {
-                if (inventoryType != null) {
-                    // survival inventory, but we want to handle a different inventory type
-                    return;
-                }
-            } else if (inventory.getInventoryType() != inventoryType) {
-                return;
-            }
+            if (!(event.getInventory() instanceof Inventory inventory)) return;
+            if (inventory.getInventoryType() != inventoryType) return; // todo what about the player's inventory?
             if (!outputSlot.isValidExternal(slot)) return;
 
             ItemStack cursor = event.getCursorItem();

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/StonecuttingInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/StonecuttingInventoryRecipes.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.crafting;
 
-import dev.goldenstack.window.InventoryView;
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.InventoryView;
+import net.goldenstack.window.Views;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
@@ -35,9 +35,8 @@ public record StonecuttingInventoryRecipes(Datapack datapack, VanillaReimplement
 
         node.addListener(InventoryClickEvent.class, event -> {
             int slot = event.getSlot();
-            if (event.getInventory() == null) return;
-            Inventory inv = event.getInventory();
-            if (event.getInventory().getInventoryType() != InventoryType.STONE_CUTTER) return;
+            if (!(event.getInventory() instanceof Inventory inv)) return;
+            if (inv.getInventoryType() != InventoryType.STONE_CUTTER) return;
 
             if (input.isValidExternal(slot)) {
                 if (!event.getClickedItem().material().equals(event.getCursorItem().material())) {
@@ -66,8 +65,7 @@ public record StonecuttingInventoryRecipes(Datapack datapack, VanillaReimplement
 
         node.addListener(PlayerPacketEvent.class, event -> {
             if (!(event.getPacket() instanceof ClientClickWindowButtonPacket packet)) return;
-            Inventory inv = event.getPlayer().getOpenInventory();
-            if (inv == null) return;
+            if (!(event.getPlayer().getOpenInventory() instanceof Inventory inv)) return;
             if (inv.getInventoryType() != InventoryType.STONE_CUTTER) return;
             int index = packet.buttonId();
 
@@ -82,6 +80,7 @@ public record StonecuttingInventoryRecipes(Datapack datapack, VanillaReimplement
 
         return node;
     }
+
     private @NotNull List<Recipe.Stonecutting> getRecipes(Material material) {
         CraftingUtils utils = new CraftingUtils(datapack);
         List<Recipe.Stonecutting> recipes = new ArrayList<>();

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/SurvivalInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/SurvivalInventoryRecipes.java
@@ -1,7 +1,8 @@
 package net.minestom.vanilla.crafting;
 
-import dev.goldenstack.window.InventoryView;
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.InventoryView;
+import net.goldenstack.window.Views;
+import net.kyori.adventure.key.Key;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
@@ -9,7 +10,6 @@ import net.minestom.server.event.inventory.InventoryClickEvent;
 import net.minestom.server.inventory.PlayerInventory;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.recipe.Recipe;
@@ -28,7 +28,7 @@ public record SurvivalInventoryRecipes(Datapack datapack, VanillaReimplementatio
             Player player = event.getPlayer();
             PlayerInventory inv = player.getInventory();
             int slot = event.getSlot();
-            if (event.getInventory() != null) return; // we only are dealing with player inventories
+            if (event.getInventory() != event.getPlayer().getInventory()) return; // we only are dealing with player inventories
 
             var crafting = Views.player().crafting();
 
@@ -66,14 +66,14 @@ public record SurvivalInventoryRecipes(Datapack datapack, VanillaReimplementatio
             for (String file : data.recipes().files()) {
                 Recipe recipe = data.recipes().file(file);
 
-                if (recipe.type().equals(NamespaceID.from("minecraft:crafting_shapeless"))) {
+                if (recipe.type().equals(Key.key("minecraft:crafting_shapeless"))) {
                     Recipe.Shapeless shapeless = (Recipe.Shapeless) recipe;
                     if (utils.recipeMatchesShapeless(shapeless, List.of(topLeft, topRight, bottomLeft, bottomRight))) {
                         return ItemStack.of(shapeless.result().id(), shapeless.result().count() == null ? 1 : shapeless.result().count());
                     }
                 }
 
-                if (recipe.type().equals(NamespaceID.from("minecraft:crafting_shaped"))) {
+                if (recipe.type().equals(Key.key("minecraft:crafting_shaped"))) {
                     Recipe.Shaped shaped = (Recipe.Shaped) recipe;
 
                     // collect materials for pattern matching

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/VriRecipeToMinestomRecipe.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/VriRecipeToMinestomRecipe.java
@@ -1,13 +1,16 @@
 package net.minestom.vanilla.crafting;
 
-import net.minestom.server.entity.Player;
+import net.kyori.adventure.key.Key;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.network.packet.server.play.DeclareRecipesPacket;
-import net.minestom.server.recipe.*;
-import net.minestom.server.utils.NamespaceID;
+import net.minestom.server.recipe.Ingredient;
+import net.minestom.server.recipe.RecipeBookCategory;
+import net.minestom.server.recipe.RecipeProperty;
+import net.minestom.server.recipe.display.RecipeDisplay;
+import net.minestom.server.recipe.display.SlotDisplay;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.DatapackUtils;
+import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.recipe.Recipe;
 import net.minestom.vanilla.logging.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
-import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 record VriRecipeToMinestomRecipe(Datapack datapack) {
 
@@ -25,28 +28,68 @@ record VriRecipeToMinestomRecipe(Datapack datapack) {
         return action.apply((V) recipe);
     }
 
-    public net.minestom.server.recipe.Recipe convert(String id, Recipe vr, Predicate<Player> shouldShow) {
+    private record MinestomRecipeImpl(
+            RecipeDisplay recipeDisplay,
+            String group,
+            RecipeBookCategory category,
+            List<Ingredient> craftingRequirements
+    ) implements net.minestom.server.recipe.Recipe {
+        @Override
+        public @NotNull List<RecipeDisplay> createRecipeDisplays() {
+            return List.of(recipeDisplay);
+        }
+
+        @Override
+        public @NotNull Map<RecipeProperty, List<Material>> itemProperties() {
+            return net.minestom.server.recipe.Recipe.super.itemProperties(); // TODO
+        }
+
+        @Override
+        public @Nullable String recipeBookGroup() {
+            return group;
+        }
+
+        @Override
+        public @Nullable RecipeBookCategory recipeBookCategory() {
+            return category;
+        }
+
+        @Override
+        public @Nullable List<Ingredient> craftingRequirements() {
+            return craftingRequirements;
+        }
+    }
+
+    public net.minestom.server.recipe.Recipe convert(String id, Recipe vr) {
         String group = Objects.requireNonNullElseGet(vr.group(), () -> "core" + ThreadLocalRandom.current().nextInt());
 
         return switch (vr.type().value()) {
-            case "blasting" -> use(vr, (Recipe.Blasting recipe) -> new BlastingRecipe(id, group, RecipeCategory.Cooking.MISC, ItemStack.of(recipe.result().id()), (float) recipe.experience(), recipe.cookingTime() == null ? 100 : recipe.cookingTime()) {
-                {
-                    this.setIngredient(toMinestom(recipe.ingredient()));
-                }
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
-            case "campfire_cooking" -> use(vr, (Recipe.CampfireCooking recipe) -> new CampfireCookingRecipe(id, group, RecipeCategory.Cooking.MISC, toItemstack(recipe.result().id()), (float) recipe.experience(), recipe.cookingTime() == null ? 100 : recipe.cookingTime()) {
-                {
-                    this.setIngredient(toMinestom(recipe.ingredient()));
-                }
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
+            case "blasting" -> use(vr, (Recipe.Blasting recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Furnace(
+                            slotDisplayOfFirst(recipe.ingredient()),
+                            SlotDisplay.AnyFuel.INSTANCE,
+                            new SlotDisplay.Item(recipe.result().id()),
+                            new SlotDisplay.Item(Material.BLAST_FURNACE),
+                            recipe.cookingTime(),
+                            (float) recipe.experience()
+                    ),
+                    group,
+                    recipe.category().equals("blocks") ? RecipeBookCategory.BLAST_FURNACE_BLOCKS : RecipeBookCategory.BLAST_FURNACE_MISC,
+                    toMinestomIngredientList(recipe.ingredient())
+            ));
+            case "campfire_cooking" -> use(vr, (Recipe.CampfireCooking recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Furnace(
+                            slotDisplayOfFirst(recipe.ingredient()),
+                            SlotDisplay.AnyFuel.INSTANCE,
+                            new SlotDisplay.Item(recipe.result().id()),
+                            new SlotDisplay.Item(Material.CAMPFIRE),
+                            recipe.cookingTime(),
+                            (float) recipe.experience()
+                    ),
+                    group,
+                    RecipeBookCategory.CAMPFIRE,
+                    toMinestomIngredientList(recipe.ingredient())
+            ));
             case "crafting_shaped" -> use(vr, (Recipe.Shaped recipe) -> {
                 int minRow = Integer.MAX_VALUE;
                 int maxRow = Integer.MIN_VALUE;
@@ -86,73 +129,148 @@ record VriRecipeToMinestomRecipe(Datapack datapack) {
                 int colCount = maxCol - minCol + 1;
                 int rowCount = maxRow - minRow + 1;
 
-                List<DeclareRecipesPacket.Ingredient> ingredients = new ArrayList<>(rowCount * colCount);
+                List<Ingredient> ingredients = new ArrayList<>(rowCount * colCount);
                 for (int row = 0; row < rowCount; row++) {
                     for (int col = 0; col < colCount; col++) {
                         // int index = row * rowPattern.length() + col;
-                        int slotIndex = (minRow + row) * rowCount + (minCol + col);
+                        int slotIndex = (minRow + row) * colCount + (minCol + col);
                         var ingredient = pos2ingredient.getOrDefault(slotIndex, new Recipe.Ingredient.None());
-                        ingredients.add(new DeclareRecipesPacket.Ingredient(toMinestom(ingredient)));
+                        List<Material> materials = toMinestom(ingredient);
+                        if (materials == null || materials.isEmpty()) ingredients.add(null);
+                        else ingredients.add(toMinestomIngredient(ingredient));
                     }
                 }
 
-                return new ShapedRecipe(id, colCount, rowCount, group, RecipeCategory.Crafting.MISC, ingredients, toItemstack(recipe.result()), true) {
-                    @Override
-                    public boolean shouldShow(@NotNull Player player) {
-                        return shouldShow.test(player);
+                List<SlotDisplay> slots = new ArrayList<>(ingredients.size());
+                for (Ingredient ingredient : ingredients) {
+                    if (ingredient == null) {
+                        slots.add(SlotDisplay.Empty.INSTANCE);
+                        continue;
                     }
-                };
-            });
-            case "crafting_shapeless" -> use(vr, (Recipe.Shapeless recipe) -> {
-                var ingredients = recipe.ingredients()
-                        .list()
-                        .stream()
-                        .map(this::toMinestom)
-                        .map(DeclareRecipesPacket.Ingredient::new)
-                        .toList();
-                return new ShapelessRecipe(id, group, RecipeCategory.Crafting.MISC, ingredients, toItemstack(recipe.result())) {
-                    @Override
-                    public boolean shouldShow(@NotNull Player player) {
-                        return shouldShow.test(player);
+                    if (ingredient.items().isEmpty()) continue;
+                    if (ingredient.items().size() == 1) {
+                        slots.add(new SlotDisplay.Item(ingredient.items().getFirst()));
+                    } else {
+                        slots.add(new SlotDisplay.Composite(
+                                ingredient.items().stream().map(SlotDisplay.Item::new).collect(Collectors.toUnmodifiableList()))
+                        );
                     }
-                };
+                }
+
+                return new MinestomRecipeImpl(
+                        new RecipeDisplay.CraftingShaped(
+                                colCount, rowCount,
+                                slots,
+                                slotDisplay(recipe.result()),
+                                new SlotDisplay.Item(Material.CRAFTING_TABLE)
+                        ),
+                        group,
+                        switch (recipe.category()) {
+                            case "equipment" -> RecipeBookCategory.CRAFTING_EQUIPMENT;
+                            case "building" -> RecipeBookCategory.CRAFTING_BUILDING_BLOCKS;
+                            case "redstone" -> RecipeBookCategory.CRAFTING_REDSTONE;
+                            default -> RecipeBookCategory.CRAFTING_MISC;
+                        },
+                        ingredients.stream().filter(Objects::nonNull).toList()
+                );
             });
-            case "smelting" -> use(vr, (Recipe.Smelting recipe) -> new SmeltingRecipe(id, group, RecipeCategory.Cooking.MISC, toItemstack(recipe.result().id()), (float) recipe.experience(), recipe.cookingTime() == null ? 100 : recipe.cookingTime()) {
-                {
-                    this.setIngredient(toMinestom(recipe.ingredient()));
-                }
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
-            case "smoking" -> use(vr, (Recipe.Smoking recipe) -> new SmokingRecipe(id, group, RecipeCategory.Cooking.MISC, toItemstack(recipe.result().id()), (float) recipe.experience(), recipe.cookingTime() == null ? 100 : recipe.cookingTime()) {
-                {
-                    this.setIngredient(toMinestom(recipe.ingredient()));
-                }
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
-            case "stonecutting" -> use(vr, (Recipe.Stonecutting recipe) -> new StonecutterRecipe(id, group, toMinestom(recipe.ingredient()), ItemStack.of(recipe.result().id(), recipe.result().count())) {
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
-            case "smithing_transform" -> use(vr, (Recipe.SmithingTransform recipe) -> new SmithingTransformRecipe(id, toMinestomIngredient(recipe.template()), toMinestomIngredient(recipe.base()), toMinestomIngredient(recipe.addition()), toItemstack(recipe.result())) {
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
-            case "smithing_trim" -> use(vr, (Recipe.SmithingTrim recipe) -> new SmithingTrimRecipe(id, toMinestomIngredient(recipe.template()), toMinestomIngredient(recipe.base()), toMinestomIngredient(recipe.addition())) {
-                @Override
-                public boolean shouldShow(@NotNull Player player) {
-                    return shouldShow.test(player);
-                }
-            });
+
+            case "crafting_shapeless" -> use(vr, (Recipe.Shapeless recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.CraftingShapeless(
+                            recipe.ingredients().stream().map(this::slotDisplay).toList(),
+                            slotDisplay(recipe.result()),
+                            new SlotDisplay.Item(Material.CRAFTING_TABLE)
+                    ),
+                    group,
+                    switch (recipe.category()) {
+                        case "equipment" -> RecipeBookCategory.CRAFTING_EQUIPMENT;
+                        case "building" -> RecipeBookCategory.CRAFTING_BUILDING_BLOCKS;
+                        case "redstone" -> RecipeBookCategory.CRAFTING_REDSTONE;
+                        default -> RecipeBookCategory.CRAFTING_MISC;
+                    },
+                    toMinestomIngredientList(recipe.ingredients())
+            ));
+
+            case "crafting_transmute" -> use(vr, (Recipe.Transmute recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.CraftingShapeless(
+                            List.of(slotDisplayOfFirst(recipe.material()), slotDisplayOfFirst(recipe.input())),
+                            slotDisplay(recipe.result()),
+                            new SlotDisplay.Item(Material.CRAFTING_TABLE)
+                    ),
+                    group,
+                    switch (recipe.category()) {
+                        case "equipment" -> RecipeBookCategory.CRAFTING_EQUIPMENT;
+                        case "building" -> RecipeBookCategory.CRAFTING_BUILDING_BLOCKS;
+                        case "redstone" -> RecipeBookCategory.CRAFTING_REDSTONE;
+                        default -> RecipeBookCategory.CRAFTING_MISC;
+                    },
+                    toMinestomIngredientList(List.of(recipe.material().getFirst(), recipe.input().getFirst()))
+            ));
+
+            case "smelting" -> use(vr, (Recipe.Smelting recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Furnace(
+                            slotDisplayOfFirst(recipe.ingredient()),
+                            SlotDisplay.AnyFuel.INSTANCE,
+                            new SlotDisplay.Item(recipe.result().id()),
+                            new SlotDisplay.Item(Material.FURNACE),
+                            recipe.cookingTime(),
+                            (float) recipe.experience()
+                    ),
+                    group,
+                    switch (recipe.category()) {
+                        case "food" -> RecipeBookCategory.FURNACE_FOOD;
+                        case "blocks" -> RecipeBookCategory.FURNACE_BLOCKS;
+                        default -> RecipeBookCategory.FURNACE_MISC;
+                    },
+                    toMinestomIngredientList(recipe.ingredient())
+            ));
+            case "smoking" -> use(vr, (Recipe.Smoking recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Furnace(
+                            slotDisplayOfFirst(recipe.ingredient()),
+                            SlotDisplay.AnyFuel.INSTANCE,
+                            new SlotDisplay.Item(recipe.result().id()),
+                            new SlotDisplay.Item(Material.SMOKER),
+                            recipe.cookingTime(),
+                            (float) recipe.experience()
+                    ),
+                    group,
+                    RecipeBookCategory.SMOKER_FOOD,
+                    toMinestomIngredientList(recipe.ingredient())
+            ));
+            case "stonecutting" -> use(vr, (Recipe.Stonecutting recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Stonecutter(
+                            slotDisplayOfFirst(recipe.ingredient()),
+                            slotDisplay(recipe.result()),
+                            new SlotDisplay.Item(Material.STONECUTTER)
+                    ),
+                    group,
+                    RecipeBookCategory.STONECUTTER,
+                    toMinestomIngredientList(recipe.ingredient())
+            ));
+            case "smithing_transform" -> use(vr, (Recipe.SmithingTransform recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Smithing(
+                            slotDisplay(recipe.template()),
+                            slotDisplay(recipe.base()),
+                            slotDisplay(recipe.addition()),
+                            slotDisplay(recipe.result()),
+                            new SlotDisplay.Item(Material.STONECUTTER)
+                    ),
+                    group,
+                    RecipeBookCategory.SMITHING,
+                    toMinestomIngredientList(List.of(recipe.template(), recipe.base(), recipe.addition()))
+            ));
+            case "smithing_trim" -> use(vr, (Recipe.SmithingTrim recipe) -> new MinestomRecipeImpl(
+                    new RecipeDisplay.Smithing(
+                            slotDisplay(recipe.template()),
+                            slotDisplay(recipe.base()),
+                            slotDisplay(recipe.addition()),
+                            SlotDisplay.Empty.INSTANCE, // TODO
+                            new SlotDisplay.Item(Material.STONECUTTER)
+                    ),
+                    group,
+                    RecipeBookCategory.SMITHING,
+                    toMinestomIngredientList(List.of(recipe.template(), recipe.base(), recipe.addition()))
+            ));
             case "native" -> {
                 Logger.warn("Native recipes are not supported yet, skipping.");
                 yield null;
@@ -164,39 +282,68 @@ record VriRecipeToMinestomRecipe(Datapack datapack) {
         };
     }
 
-    private ItemStack toItemstack(Recipe.Result result) {
-        return ItemStack.of(result.id(), result.count() == null ? 1 : result.count());
-    }
-
-    private ItemStack toItemstack(Material result) {
-        return ItemStack.of(result);
-    }
-
-    public DeclareRecipesPacket.@NotNull Ingredient toMinestom(List<Recipe.Ingredient> ingredients) {
+    public List<Ingredient> toMinestomIngredientList(List<Recipe.Ingredient> ingredients) {
         if (ingredients.isEmpty()) {
-            return new DeclareRecipesPacket.Ingredient((List<ItemStack>) null);
+            return List.of();
         }
 
-        return new DeclareRecipesPacket.Ingredient(ingredients.stream()
+        List<Material> materials = ingredients.stream()
                 .map(this::toMinestom)
                 .filter(Objects::nonNull)
                 .flatMap(Collection::stream)
-                .toList());
+                .toList();
+
+        if (materials.isEmpty()) return List.of();
+
+        return List.of(new Ingredient(materials));
     }
 
-    public DeclareRecipesPacket.Ingredient toMinestomIngredient(Recipe.Ingredient ingredient) {
-        return new DeclareRecipesPacket.Ingredient(toMinestom(ingredient));
+    public Ingredient toMinestomIngredient(Recipe.Ingredient ingredient) {
+        return new Ingredient(toMinestom(ingredient));
     }
 
-    public @Nullable List<ItemStack> toMinestom(@Nullable Recipe.Ingredient ingredient) {
+    public SlotDisplay slotDisplay(Recipe.Result result) {
+        return new SlotDisplay.ItemStack(ItemStack.of(result.id(), result.count() != null ? result.count() : 1));
+    }
+
+    public SlotDisplay slotDisplayOfFirst(JsonUtils.SingleOrList<Recipe.Ingredient> ingredients) {
+        return slotDisplay(ingredients.getFirst());
+    }
+
+    public SlotDisplay slotDisplay(@Nullable Recipe.Ingredient ingredient) {
+        switch (ingredient) {
+            case Recipe.Ingredient.Multi multi -> {
+                return new SlotDisplay.Composite(
+                        multi.items().stream().map(this::slotDisplay).toList()
+                );
+            }
+            case Recipe.Ingredient.Single single -> {
+                List<Material> materials = toMinestom(single);
+                if (materials == null || materials.isEmpty()) {
+                    return SlotDisplay.Empty.INSTANCE;
+                }
+                if (materials.size() == 1) {
+                    return new SlotDisplay.Item(materials.getFirst());
+                } else {
+                    return new SlotDisplay.Composite(
+                            materials.stream().map(SlotDisplay.Item::new).collect(Collectors.toUnmodifiableList())
+                    );
+                }
+            }
+            case null, default -> {
+                return SlotDisplay.Empty.INSTANCE;
+            }
+        }
+    }
+
+    public @Nullable List<Material> toMinestom(@Nullable Recipe.Ingredient ingredient) {
         if (ingredient instanceof Recipe.Ingredient.Item item) {
-            return List.of(toItemstack(item.item()));
+            return List.of(item.item());
         } else if (ingredient instanceof Recipe.Ingredient.Tag tag) {
             return DatapackUtils.findTags(datapack, "item", tag.tag()).stream()
-                    .map(NamespaceID::from)
-                    .map(Material::fromNamespaceId)
+                    .map(Key::key)
+                    .map(Material::fromKey)
                     .filter(Objects::nonNull)
-                    .map(ItemStack::of)
                     .toList();
         } else if (ingredient instanceof Recipe.Ingredient.Multi multi) {
             return multi.items()

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/BlastingInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/BlastingInventoryRecipes.java
@@ -1,6 +1,6 @@
 package net.minestom.vanilla.crafting.smelting;
 
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.Views;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.instance.block.Block;

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmeltingHandler.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmeltingHandler.java
@@ -1,6 +1,6 @@
 package net.minestom.vanilla.crafting.smelting;
 
-import dev.goldenstack.window.InventoryView;
+import net.goldenstack.window.InventoryView;
 import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.inventory.Inventory;
@@ -8,8 +8,7 @@ import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.server.network.packet.server.play.WindowPropertyPacket;
 import net.minestom.server.tag.Tag;
-import net.minestom.server.utils.NamespaceID;
-import net.minestom.server.utils.PacketUtils;
+import net.minestom.server.utils.PacketSendingUtils;
 import net.minestom.vanilla.crafting.CraftingUtils;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.DatapackUtils;
@@ -44,7 +43,7 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
             if (!Material.AIR.equals(lastCookedItem)) {
                 // this means that the furnace was cooking, but ran out of fuel
                 WindowPropertyPacket clearProgress = new WindowPropertyPacket(inventory.getWindowId(), (short) 0, (short) 0);
-                PacketUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
+                PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
                 return block.withTag(Tags.Blocks.Smelting.LAST_COOKED_ITEM, Material.AIR);
             }
 
@@ -53,7 +52,7 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
                 // we've stopped cooking, but we can't start cooking again
                 // reset the current progress
                 WindowPropertyPacket clearProgress = new WindowPropertyPacket(inventory.getWindowId(), (short) 2, (short) 0);
-                PacketUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
+                PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
                 return block.withTag(Tags.Blocks.Smelting.COOKING_PROGRESS, 0);
             }
 
@@ -74,13 +73,13 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
             Block newBlock = block.withTag(Tags.Blocks.Smelting.COOKING_TICKS, cookingTicks);
             if (cookingProgress != 0) {
                 WindowPropertyPacket clearProgress = new WindowPropertyPacket(inventory.getWindowId(), (short) 2, (short) 0);
-                PacketUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
+                PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
                 newBlock = newBlock.withTag(Tags.Blocks.Smelting.COOKING_PROGRESS, 0);
             }
             WindowPropertyPacket maximumFuelBurnTime = new WindowPropertyPacket(inventory.getWindowId(), (short) 1, lastCookedItemBurnTicks == null ? (short) 0 : lastCookedItemBurnTicks.shortValue());
             WindowPropertyPacket fuelBurnTime = new WindowPropertyPacket(inventory.getWindowId(), (short) 0, (short) cookingTicks);
-            PacketUtils.sendGroupedPacket(inventory.getViewers(), maximumFuelBurnTime);
-            PacketUtils.sendGroupedPacket(inventory.getViewers(), fuelBurnTime);
+            PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), maximumFuelBurnTime);
+            PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), fuelBurnTime);
             return newBlock;
         }
 
@@ -109,10 +108,10 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
 
         // TODO: Bundle these packets together
 
-        PacketUtils.sendGroupedPacket(inventory.getViewers(), maximumFuelBurnTime);
-        PacketUtils.sendGroupedPacket(inventory.getViewers(), fuelBurnTime);
-        PacketUtils.sendGroupedPacket(inventory.getViewers(), maximumProgress);
-        PacketUtils.sendGroupedPacket(inventory.getViewers(), progress);
+        PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), maximumFuelBurnTime);
+        PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), fuelBurnTime);
+        PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), maximumProgress);
+        PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), progress);
 
         if (cookingProgress >= recipeCompleteTicks) {
             // recipe complete
@@ -127,7 +126,7 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
 
             // clear cooking progress
             WindowPropertyPacket clearProgress = new WindowPropertyPacket(inventory.getWindowId(), (short) 2, (short) 0);
-            PacketUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
+            PacketSendingUtils.sendGroupedPacket(inventory.getViewers(), clearProgress);
         }
 
         return block.withTag(Tags.Blocks.Smelting.COOKING_PROGRESS, cookingProgress)
@@ -204,8 +203,8 @@ public record SmeltingHandler(Datapack datapack, int speed, Map<Material, Intege
     }
 
     private static void addItemTags(Datapack datapack, Map<Material, Integer> material2burnTicks, String tagName, int burnTime) {
-        for (Key item : DatapackUtils.findTags(datapack, "item", NamespaceID.from(tagName))) {
-            Material mat = Material.fromNamespaceId(item.asString());
+        for (Key item : DatapackUtils.findTags(datapack, "item", Key.key(tagName))) {
+            Material mat = Material.fromKey(item.asString());
             material2burnTicks.put(mat, burnTime);
         }
     }

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmeltingInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmeltingInventoryRecipes.java
@@ -1,6 +1,6 @@
 package net.minestom.vanilla.crafting.smelting;
 
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.Views;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.instance.block.Block;

--- a/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmokingInventoryRecipes.java
+++ b/crafting/src/main/java/net/minestom/vanilla/crafting/smelting/SmokingInventoryRecipes.java
@@ -1,6 +1,6 @@
 package net.minestom.vanilla.crafting.smelting;
 
-import dev.goldenstack.window.Views;
+import net.goldenstack.window.Views;
 import net.minestom.server.event.Event;
 import net.minestom.server.event.EventNode;
 import net.minestom.server.instance.block.Block;

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/Datapack.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/Datapack.java
@@ -1,26 +1,27 @@
 package net.minestom.vanilla.datapack;
 
 import com.squareup.moshi.JsonReader;
+import net.kyori.adventure.key.Key;
+import net.minestom.vanilla.datapack.advancement.Advancement;
 import net.minestom.vanilla.datapack.dimension.DimensionType;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;
+import net.minestom.vanilla.datapack.loot.LootTable;
+import net.minestom.vanilla.datapack.loot.function.LootFunction;
+import net.minestom.vanilla.datapack.loot.function.Predicate;
+import net.minestom.vanilla.datapack.recipe.Recipe;
 import net.minestom.vanilla.datapack.trims.TrimMaterial;
 import net.minestom.vanilla.datapack.trims.TrimPattern;
 import net.minestom.vanilla.datapack.worldgen.*;
 import net.minestom.vanilla.datapack.worldgen.noise.Noise;
 import net.minestom.vanilla.files.ByteArray;
 import net.minestom.vanilla.files.FileSystem;
-import net.kyori.adventure.key.Key;
-import net.minestom.vanilla.datapack.advancement.Advancement;
-import net.minestom.vanilla.datapack.loot.LootTable;
-import net.minestom.vanilla.datapack.loot.function.LootFunction;
-import net.minestom.vanilla.datapack.loot.function.Predicate;
-import net.minestom.vanilla.datapack.recipe.Recipe;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 
 public interface Datapack {
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/DatapackLoadingFeature.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/DatapackLoadingFeature.java
@@ -1,13 +1,11 @@
 package net.minestom.vanilla.datapack;
 
 import io.github.pesto.MojangDataFeature;
-import net.minestom.server.utils.NamespaceID;
-import net.minestom.vanilla.files.ByteArray;
-import net.minestom.vanilla.files.FileSystem;
 import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.VanillaReimplementation;
+import net.minestom.vanilla.files.ByteArray;
+import net.minestom.vanilla.files.FileSystem;
 import net.minestom.vanilla.logging.Loading;
-import net.minestom.vanilla.logging.Logger;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.UnknownNullability;
 
@@ -35,8 +33,8 @@ public class DatapackLoadingFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:datapack");
+    public @NotNull Key key() {
+        return Key.key("vri:datapack");
     }
 
     @Override

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/advancement/Advancement.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/advancement/Advancement.java
@@ -1,9 +1,9 @@
 package net.minestom.vanilla.datapack.advancement;
 
 import com.squareup.moshi.JsonReader;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.minestom.server.instance.block.Block;
-import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;
 import net.minestom.vanilla.datapack.loot.function.Predicate;

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/LootTable.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/LootTable.java
@@ -1,11 +1,10 @@
 package net.minestom.vanilla.datapack.loot;
 
 import com.squareup.moshi.JsonReader;
+import net.kyori.adventure.key.Key;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.kyori.adventure.key.Key;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.DatapackUtils;
 import net.minestom.vanilla.datapack.json.JsonUtils;
@@ -87,7 +86,7 @@ public record LootTable(@Nullable String type, @Nullable List<LootFunction> func
                 @Override
                 public List<List<ItemStack>> apply(Datapack datapack, LootContext context) {
                     return List.of(List.of(
-                            ItemStack.of(Objects.requireNonNull(Material.fromNamespaceId(NamespaceID.from(name))), count == null ? 1 : count)
+                            ItemStack.of(Objects.requireNonNull(Material.fromKey(name)), count == null ? 1 : count)
                     ));
                 }
             }
@@ -120,8 +119,7 @@ public record LootTable(@Nullable String type, @Nullable List<LootFunction> func
                     var itemTags = DatapackUtils.findTags(datapack, "item", name);
 
                     var items = itemTags.stream()
-                            .map(NamespaceID::from)
-                            .map(Material::fromNamespaceId)
+                            .map(Material::fromKey)
                             .filter(Objects::nonNull)
                             .map(material -> ItemStack.of(material, 1))
                             .toList();

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/function/InBuiltPredicates.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/function/InBuiltPredicates.java
@@ -1,16 +1,15 @@
 package net.minestom.vanilla.datapack.loot.function;
 
 import com.squareup.moshi.JsonReader;
+import net.kyori.adventure.key.Key;
+import net.minestom.server.component.DataComponents;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.item.ItemComponent;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.component.EnchantmentList;
 import net.minestom.server.item.enchant.Enchantment;
 import net.minestom.server.registry.DynamicRegistry;
-import net.kyori.adventure.key.Key;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.datapack.DatapackLoader;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;
@@ -304,7 +303,7 @@ interface InBuiltPredicates {
 
             Player player = context.get(LootContext.KILLER_PLAYER);
             if (player != null) {
-                EnchantmentList enchants = player.getItemInMainHand().get(ItemComponent.ENCHANTMENTS);
+                EnchantmentList enchants = player.getItemInMainHand().get(DataComponents.ENCHANTMENTS);
                 if (enchants != null && enchants.has(Enchantment.LOOTING)) {
                     looting = enchants.level(Enchantment.LOOTING);
                 }
@@ -362,8 +361,8 @@ interface InBuiltPredicates {
         @Override
         public boolean test(LootContext context) {
             ItemStack item = context.getOrThrow(LootContext.TOOL);
-            EnchantmentList enchants = item.get(ItemComponent.ENCHANTMENTS);
-            DynamicRegistry.Key<Enchantment> enchantment = MinestomUtils.getEnchantKey(NamespaceID.from(this.enchantment));
+            EnchantmentList enchants = item.get(DataComponents.ENCHANTMENTS);
+            DynamicRegistry.Key<Enchantment> enchantment = MinestomUtils.getEnchantKey(this.enchantment);
             int level = enchants == null || !enchants.has(enchantment) ? 0 : enchants.level(enchantment);
 
             return ThreadLocalRandom.current().nextFloat() < chances.get(level);

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/function/LootFunction.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/loot/function/LootFunction.java
@@ -1,8 +1,8 @@
 package net.minestom.vanilla.datapack.loot.function;
 
 import com.squareup.moshi.JsonReader;
-import net.minestom.server.item.ItemStack;
 import net.kyori.adventure.key.Key;
+import net.minestom.server.item.ItemStack;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.loot.context.LootContext;
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/trims/TrimMaterial.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/trims/TrimMaterial.java
@@ -12,9 +12,7 @@ import java.util.Map;
  asset_name: A string which will be used in the resource pack.
  description: A JSON text component used for the tooltip on items. The color
  #258474 is used here.
- ingredient: The item representing this material.
- item_model_index: A value between 0 and 1, used in the item models (see below).
  override_armor_materials: Optional. Map of armor material to override color palette.
  */
-public record TrimMaterial(String asset_name, Component description, Key ingredient, float item_model_index, @Optional Map<Key, String> override_armor_materials) {
+public record TrimMaterial(String asset_name, Component description, @Optional Map<Key, String> override_armor_materials) {
 }

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/trims/TrimPattern.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/trims/TrimPattern.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.datapack.trims;
 
-import net.kyori.adventure.text.Component;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
 import net.minestom.vanilla.datapack.json.Optional;
 
 /**

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Biome.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Biome.java
@@ -1,10 +1,8 @@
 package net.minestom.vanilla.datapack.worldgen;
 
 import com.squareup.moshi.JsonReader;
-import net.kyori.adventure.nbt.BinaryTag;
-import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.key.Key;
-import net.minestom.vanilla.datapack.Datapack;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.minestom.vanilla.datapack.DatapackLoader;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;
@@ -36,7 +34,7 @@ public record Biome(
         @Optional TemperatureModifier temperature_modifier,
         float downfall,
         Effects effects,
-        Carvers carvers,
+        CarversList carvers,
         Object features,
         @Optional Float creature_spawn_probability,
         Map<MobCategory, List<SpawnerData>> spawners,
@@ -112,7 +110,7 @@ public record Biome(
             @Optional Sound ambient_sound,
             @Optional MoodSound mood_sound,
             @Optional AdditionsSound additions_sound,
-            @Optional Music music
+            @Optional List<Music> music
     ) {
 
         /**
@@ -316,11 +314,11 @@ public record Biome(
         /**
          * Represents music settings for a biome.
          */
-        public record Music(Sound sound, int min_delay, int max_delay, boolean replace_current_music) {
+        public record Music(MusicData data, double weight) {
         }
-    }
 
-    public record Carvers(@Optional CarversList air, @Optional CarversList liquid) {
+        public record MusicData(Sound sound, int min_delay, int max_delay, boolean replace_current_music) {
+        }
     }
 
     public interface CarversList {

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/BlockState.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/BlockState.java
@@ -10,7 +10,7 @@ import java.util.Objects;
 
 public record BlockState(String name, Map<String, String> properties) {
     public Block toMinestom() {
-        return Objects.requireNonNull(Block.fromNamespaceId(name), () -> "Unknown block: " + name)
+        return Objects.requireNonNull(Block.fromKey(name), () -> "Unknown block: " + name)
                 .withProperties(properties);
     }
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Carver.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Carver.java
@@ -1,8 +1,8 @@
 package net.minestom.vanilla.datapack.worldgen;
 
 import com.squareup.moshi.JsonReader;
-import net.minestom.server.instance.block.Block;
 import net.kyori.adventure.key.Key;
+import net.minestom.server.instance.block.Block;
 import net.minestom.vanilla.datapack.DatapackLoader;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/HeightProvider.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/HeightProvider.java
@@ -2,7 +2,6 @@ package net.minestom.vanilla.datapack.worldgen;
 
 import com.squareup.moshi.JsonReader;
 import net.kyori.adventure.key.Key;
-import net.minestom.vanilla.datapack.DatapackLoader;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.json.Optional;
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/NoiseSettings.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/NoiseSettings.java
@@ -4,9 +4,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.squareup.moshi.JsonReader;
-import net.minestom.server.instance.block.Block;
 import net.kyori.adventure.key.Key;
-import net.minestom.server.utils.math.FloatRange;
+import net.minestom.server.instance.block.Block;
+import net.minestom.server.utils.Range;
 import net.minestom.vanilla.datapack.json.JsonUtils;
 import net.minestom.vanilla.datapack.worldgen.noise.NormalNoise;
 import net.minestom.vanilla.datapack.worldgen.random.WorldgenRandom;
@@ -44,12 +44,12 @@ public record NoiseSettings(
     }
 
     // Noise parameter for biome
-    public record SpawnTarget(FloatRange temperature,
-                              FloatRange humidity,
-                              FloatRange continentalness,
-                              FloatRange erosion,
-                              FloatRange weirdness,
-                              FloatRange depth,
+    public record SpawnTarget(Range.Float temperature,
+                              Range.Float humidity,
+                              Range.Float continentalness,
+                              Range.Float erosion,
+                              Range.Float weirdness,
+                              Range.Float depth,
                               float offset) {
     }
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Structure.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/Structure.java
@@ -1,9 +1,9 @@
 package net.minestom.vanilla.datapack.worldgen;
 
 import net.kyori.adventure.nbt.*;
-import net.minestom.vanilla.files.ByteArray;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
+import net.minestom.vanilla.files.ByteArray;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/VerticalAnchor.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/VerticalAnchor.java
@@ -1,7 +1,6 @@
 package net.minestom.vanilla.datapack.worldgen;
 
 import com.squareup.moshi.JsonReader;
-import net.minestom.vanilla.datapack.json.JsonUtils;
 
 import java.io.IOException;
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/math/CubicSpline.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/math/CubicSpline.java
@@ -7,7 +7,10 @@ import net.minestom.vanilla.datapack.worldgen.DensityFunction;
 import net.minestom.vanilla.datapack.worldgen.util.Util;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 public interface CubicSpline extends NumberFunction<DensityFunction.Context> {
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/noise/BlendedNoise.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/noise/BlendedNoise.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.datapack.worldgen.noise;
 
-import net.minestom.vanilla.datapack.worldgen.util.Util;
 import net.minestom.vanilla.datapack.worldgen.random.WorldgenRandom;
+import net.minestom.vanilla.datapack.worldgen.util.Util;
 import org.jetbrains.annotations.Nullable;
 
 public class BlendedNoise implements Noise {

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/noise/ImprovedNoise.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/noise/ImprovedNoise.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.datapack.worldgen.noise;
 
-import net.minestom.vanilla.datapack.worldgen.util.Util;
 import net.minestom.vanilla.datapack.worldgen.random.WorldgenRandom;
+import net.minestom.vanilla.datapack.worldgen.util.Util;
 
 public class ImprovedNoise implements Noise {
 

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/storage/DoubleStorageCache2d.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/storage/DoubleStorageCache2d.java
@@ -2,7 +2,7 @@ package net.minestom.vanilla.datapack.worldgen.storage;
 
 import it.unimi.dsi.fastutil.longs.Long2DoubleMap;
 import it.unimi.dsi.fastutil.longs.Long2DoubleOpenHashMap;
-import net.minestom.server.utils.chunk.ChunkUtils;
+import net.minestom.server.coordinate.CoordConversion;
 
 class DoubleStorageCache2d implements DoubleStorage {
 
@@ -19,6 +19,6 @@ class DoubleStorageCache2d implements DoubleStorage {
     }
 
     private long getIndex(int x, int z) {
-        return ChunkUtils.getChunkIndex(x, z);
+        return CoordConversion.chunkIndex(x, z);
     }
 }

--- a/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/util/Util.java
+++ b/datapack-loading/src/main/java/net/minestom/vanilla/datapack/worldgen/util/Util.java
@@ -1,26 +1,15 @@
 package net.minestom.vanilla.datapack.worldgen.util;
 
-import com.google.gson.*;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.instance.Chunk;
-import net.minestom.server.instance.block.Block;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.io.IOException;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.function.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 public class Util {

--- a/datapack-tests/build.gradle.kts
+++ b/datapack-tests/build.gradle.kts
@@ -18,7 +18,7 @@ tasks.test {
 }
 
 minecraft {
-    version("1.20.4")
+    version("1.21.5")
     runs {
         server()
     }

--- a/datapack-tests/src/test/java/net/minestom/vanilla/datapack/loot/LootTableTestData.java
+++ b/datapack-tests/src/test/java/net/minestom/vanilla/datapack/loot/LootTableTestData.java
@@ -1,7 +1,6 @@
 package net.minestom.vanilla.datapack.loot;
 
 import net.kyori.adventure.nbt.CompoundBinaryTag;
-import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
 import net.minestom.vanilla.datapack.loot.context.LootContext;

--- a/datapack-tests/src/test/java/net/minestom/vanilla/datapack/worldgen/DF.java
+++ b/datapack-tests/src/test/java/net/minestom/vanilla/datapack/worldgen/DF.java
@@ -18,7 +18,7 @@ interface DF {
     static DF vanilla(String source) {
         JsonElement element = new Gson().fromJson(source, JsonElement.class);
         var result = net.minecraft.world.level.levelgen.DensityFunction.HOLDER_HELPER_CODEC.parse(JsonOps.INSTANCE, element);
-        var df = result.getOrThrow(false, error -> { throw new RuntimeException(error); });
+        var df = result.getOrThrow(error -> { throw new RuntimeException(error); });
         return new VanillaDF(df);
     }
 

--- a/entities/src/main/java/net/minestom/vanilla/entities/MinestomEntitiesFeature.java
+++ b/entities/src/main/java/net/minestom/vanilla/entities/MinestomEntitiesFeature.java
@@ -1,7 +1,7 @@
 package net.minestom.vanilla.entities;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.entity.EntityType;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
 
@@ -14,7 +14,7 @@ public class MinestomEntitiesFeature implements VanillaReimplementation.Feature 
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:entities");
+    public @NotNull Key key() {
+        return Key.key("vri:entities");
     }
 }

--- a/entities/src/main/java/net/minestom/vanilla/entities/PrimedTNTEntity.java
+++ b/entities/src/main/java/net/minestom/vanilla/entities/PrimedTNTEntity.java
@@ -1,6 +1,5 @@
 package net.minestom.vanilla.entities;
 
-import net.minestom.server.collision.Aerodynamics;
 import net.minestom.server.entity.Entity;
 import net.minestom.server.entity.EntityType;
 import net.minestom.server.entity.metadata.other.PrimedTntMeta;

--- a/entity-meta/src/main/java/net/minestom/vanilla/entitymeta/EntityTags.java
+++ b/entity-meta/src/main/java/net/minestom/vanilla/entitymeta/EntityTags.java
@@ -8,7 +8,7 @@ public interface EntityTags {
 
     interface FallingBlock {
         @NotNull Tag<Block> BLOCK = Tag.String("vri:entity-meta.falling_block.block")
-                .map(Block::fromNamespaceId, block -> block.namespace().toString());
+                .map(Block::fromKey, block -> block.key().toString());
     }
 
     interface PrimedTnt {

--- a/fluid-simulation/src/main/java/io/github/togar2/fluids/FlowableFluid.java
+++ b/fluid-simulation/src/main/java/io/github/togar2/fluids/FlowableFluid.java
@@ -254,7 +254,7 @@ public abstract class FlowableFluid extends Fluid {
                 || block.compare(Block.SEAGRASS)
                 || block.compare(Block.TALL_SEAGRASS)
                 || block.compare(Block.SEA_PICKLE)
-                || Objects.requireNonNull(tags.getTag(Tag.BasicType.BLOCKS, "minecraft:signs")).contains(block.namespace())
+                || Objects.requireNonNull(tags.getTag(Tag.BasicType.BLOCKS, "minecraft:signs")).contains(block.key())
                 || block.name().contains("door")
                 || block.name().contains("coral")) {
             return false;

--- a/fluid-simulation/src/main/java/io/github/togar2/fluids/FluidSimulationFeature.java
+++ b/fluid-simulation/src/main/java/io/github/togar2/fluids/FluidSimulationFeature.java
@@ -1,6 +1,7 @@
 package io.github.togar2.fluids;
 
-import net.minestom.server.utils.NamespaceID;
+
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.BlockUpdateFeature;
 import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
@@ -16,8 +17,8 @@ public class FluidSimulationFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("io.github.togar2:fluids");
+    public @NotNull Key key() {
+        return Key.key("io.github.togar2:fluids");
     }
 
     @NotNull

--- a/fluid-simulation/src/main/java/io/github/togar2/fluids/WaterBlockBreakEvent.java
+++ b/fluid-simulation/src/main/java/io/github/togar2/fluids/WaterBlockBreakEvent.java
@@ -1,7 +1,6 @@
 package io.github.togar2.fluids;
 
 import net.minestom.server.coordinate.BlockVec;
-import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.trait.BlockEvent;
 import net.minestom.server.event.trait.CancellableEvent;
 import net.minestom.server.event.trait.InstanceEvent;

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-minestom_version=d955f51899
+minestom_version=1_21_5-74ed5739a9
 rayfast_version=684e854a48
 jnoise_version=4.0.0
 annotations_version=23.0.0
-window_version=a2feac67eb
+window_version=1.1

--- a/instance-meta/src/main/java/net/minestom/vanilla/instancemeta/InstanceMetaFeature.java
+++ b/instance-meta/src/main/java/net/minestom/vanilla/instancemeta/InstanceMetaFeature.java
@@ -1,8 +1,8 @@
 package net.minestom.vanilla.instancemeta;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.event.instance.InstanceTickEvent;
 import net.minestom.server.instance.Instance;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.instancemeta.tickets.TicketManager;
 import org.jetbrains.annotations.NotNull;
@@ -20,8 +20,8 @@ public class InstanceMetaFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:instancemeta");
+    public @NotNull Key key() {
+        return Key.key("vri:instancemeta");
     }
 
     private static class Logic {

--- a/instance-meta/src/main/java/net/minestom/vanilla/instancemeta/tickets/TicketManager.java
+++ b/instance-meta/src/main/java/net/minestom/vanilla/instancemeta/tickets/TicketManager.java
@@ -8,11 +8,11 @@ import it.unimi.dsi.fastutil.objects.Object2ShortMap;
 import it.unimi.dsi.fastutil.objects.Object2ShortOpenHashMap;
 import it.unimi.dsi.fastutil.shorts.Short2IntMap;
 import it.unimi.dsi.fastutil.shorts.Short2IntOpenHashMap;
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.tag.Tag;
 import net.minestom.server.tag.TagReadable;
 import net.minestom.server.tag.TagSerializer;
 import net.minestom.server.tag.TagWritable;
-import net.minestom.server.utils.chunk.ChunkUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -137,8 +137,8 @@ public class TicketManager {
 
         // Add values to surrounding external
         short currentSourceValue = value;
-        int originX = ChunkUtils.getChunkCoordX(chunk);
-        int originZ = ChunkUtils.getChunkCoordZ(chunk);
+        int originX = CoordConversion.chunkIndexGetX(chunk);
+        int originZ = CoordConversion.chunkIndexGetZ(chunk);
 
         while (currentSourceValue > 1) {
             // Find starting positions + starting external value
@@ -165,25 +165,25 @@ public class TicketManager {
             for (int offset = 0; offset < ((halfWidth * 2) + 1); offset++) {
 
                 { // Left side
-                    long chunkIndex = ChunkUtils.getChunkIndex(leftX, leftZ - offset);
+                    long chunkIndex = CoordConversion.chunkIndex(leftX, leftZ - offset);
                     externalTicketValues.put(new Source2Target(chunkIndex, chunk), externalValue);
                     recalculateChunkValue(chunkIndex);
                 }
 
                 { // Top side
-                    long chunkIndex = ChunkUtils.getChunkIndex(topX + offset, topZ);
+                    long chunkIndex = CoordConversion.chunkIndex(topX + offset, topZ);
                     externalTicketValues.put(new Source2Target(chunkIndex, chunk), externalValue);
                     recalculateChunkValue(chunkIndex);
                 }
 
                 { // Right side
-                    long chunkIndex = ChunkUtils.getChunkIndex(rightX, rightZ + offset);
+                    long chunkIndex = CoordConversion.chunkIndex(rightX, rightZ + offset);
                     externalTicketValues.put(new Source2Target(chunkIndex, chunk), externalValue);
                     recalculateChunkValue(chunkIndex);
                 }
 
                 { // Downside
-                    long chunkIndex = ChunkUtils.getChunkIndex(downX - offset, downZ);
+                    long chunkIndex = CoordConversion.chunkIndex(downX - offset, downZ);
                     externalTicketValues.put(new Source2Target(chunkIndex, chunk), externalValue);
                     recalculateChunkValue(chunkIndex);
                 }
@@ -233,8 +233,8 @@ public class TicketManager {
         }
 
         short previousSourceValue = value;
-        int originX = ChunkUtils.getChunkCoordX(chunk);
-        int originZ = ChunkUtils.getChunkCoordZ(chunk);
+        int originX = CoordConversion.chunkIndexGetX(chunk);
+        int originZ = CoordConversion.chunkIndexGetZ(chunk);
 
         while (previousSourceValue > 1) {
             // Find starting positions + starting external value
@@ -260,7 +260,7 @@ public class TicketManager {
             for (int offset = 0; offset < ((halfWidth * 2) + 1); offset++) {
 
                 { // Left side
-                    long chunkIndex = ChunkUtils.getChunkIndex(leftX, leftZ - offset);
+                    long chunkIndex = CoordConversion.chunkIndex(leftX, leftZ - offset);
                     if (highestInternalValue <= 0) {
                         externalTicketValues.removeShort(new Source2Target(chunkIndex, chunk));
                     } else {
@@ -270,7 +270,7 @@ public class TicketManager {
                 }
 
                 { // Top side
-                    long chunkIndex = ChunkUtils.getChunkIndex(topX + offset, topZ);
+                    long chunkIndex = CoordConversion.chunkIndex(topX + offset, topZ);
                     if (highestInternalValue <= 0) {
                         externalTicketValues.removeShort(new Source2Target(chunkIndex, chunk));
                     } else {
@@ -280,7 +280,7 @@ public class TicketManager {
                 }
 
                 { // Right side
-                    long chunkIndex = ChunkUtils.getChunkIndex(rightX, rightZ + offset);
+                    long chunkIndex = CoordConversion.chunkIndex(rightX, rightZ + offset);
                     if (highestInternalValue <= 0) {
                         externalTicketValues.removeShort(new Source2Target(chunkIndex, chunk));
                     } else {
@@ -290,7 +290,7 @@ public class TicketManager {
                 }
 
                 { // Downside
-                    long chunkIndex = ChunkUtils.getChunkIndex(downX - offset, downZ);
+                    long chunkIndex = CoordConversion.chunkIndex(downX - offset, downZ);
                     if (highestInternalValue <= 0) {
                         externalTicketValues.removeShort(new Source2Target(chunkIndex, chunk));
                     } else {

--- a/item-placeables/src/main/java/net/minestom/vanilla/itemplaceables/ItemPlaceablesFeature.java
+++ b/item-placeables/src/main/java/net/minestom/vanilla/itemplaceables/ItemPlaceablesFeature.java
@@ -1,11 +1,11 @@
 package net.minestom.vanilla.itemplaceables;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.event.player.PlayerUseItemOnBlockEvent;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.item.ItemStack;
 import net.minestom.server.item.Material;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
 
@@ -36,7 +36,7 @@ public class ItemPlaceablesFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:item-placeables");
+    public @NotNull Key key() {
+        return Key.key("vri:item-placeables");
     }
 }

--- a/items/src/main/java/net/minestom/vanilla/items/FlintAndSteelHandler.java
+++ b/items/src/main/java/net/minestom/vanilla/items/FlintAndSteelHandler.java
@@ -2,6 +2,7 @@ package net.minestom.vanilla.items;
 
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.entity.Player;
+import net.minestom.server.entity.PlayerHand;
 import net.minestom.server.event.player.PlayerUseItemOnBlockEvent;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
@@ -21,7 +22,7 @@ public class FlintAndSteelHandler implements VanillaItemHandler {
         Player player = event.getPlayer();
         Instance instance = player.getInstance();
         ItemStack itemStack = event.getItemStack();
-        Player.Hand hand = event.getHand();
+        PlayerHand hand = event.getHand();
         Direction blockDir = event.getBlockFace().toDirection();
 
         // Find block in direction

--- a/items/src/main/java/net/minestom/vanilla/items/ItemsFeature.java
+++ b/items/src/main/java/net/minestom/vanilla/items/ItemsFeature.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.items;
 
-import net.minestom.server.utils.NamespaceID;
+
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
 
@@ -17,7 +18,7 @@ public class ItemsFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:items");
+    public @NotNull Key key() {
+        return Key.key("vri:items");
     }
 }

--- a/mojang-data/src/main/java/io/github/pesto/MojangAssets.java
+++ b/mojang-data/src/main/java/io/github/pesto/MojangAssets.java
@@ -18,7 +18,8 @@ import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.CompletableFuture;
 
-import static java.nio.file.StandardOpenOption.*;
+import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
+import static java.nio.file.StandardOpenOption.WRITE;
 
 final class MojangAssets {
     private static final File ROOT = new File(".", "mojang-data");

--- a/mojang-data/src/main/java/io/github/pesto/MojangDataFeature.java
+++ b/mojang-data/src/main/java/io/github/pesto/MojangDataFeature.java
@@ -1,16 +1,16 @@
 package io.github.pesto;
 
+import net.kyori.adventure.key.Key;
+import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.files.ByteArray;
 import net.minestom.vanilla.files.FileSystem;
-import net.minestom.server.utils.NamespaceID;
-import net.minestom.vanilla.VanillaReimplementation;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.concurrent.CompletableFuture;
 
 public class MojangDataFeature implements VanillaReimplementation.Feature {
 
-    private static final String LATEST = "1.21.1";
+    private static final String LATEST = "1.21.5";
     private final MojangAssets assets = new MojangAssets();
     private final CompletableFuture<FileSystem<ByteArray>> latest = new CompletableFuture<>();
 
@@ -22,8 +22,8 @@ public class MojangDataFeature implements VanillaReimplementation.Feature {
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("io_github_pesto:mojang_data");
+    public @NotNull Key key() {
+        return Key.key("io_github_pesto:mojang_data");
     }
 
     public FileSystem<ByteArray> latestAssets() {

--- a/server/src/main/java/net/minestom/vanilla/server/VanillaDebug.java
+++ b/server/src/main/java/net/minestom/vanilla/server/VanillaDebug.java
@@ -22,7 +22,7 @@ public class VanillaDebug {
     public static void hook(VanillaServer server) {
         VanillaReimplementation vri = server.vri();
         vri.process().eventHandler()
-                .addListener(PlayerChatEvent.class, event -> handleMessage(server, event.getPlayer(), event.getMessage()))
+                .addListener(PlayerChatEvent.class, event -> handleMessage(server, event.getPlayer(), event.getRawMessage()))
 //            .addListener(PlayerTickEvent.class, event -> {
 //                if (event.getPlayer().getInstance().getWorldAge() % 10 == 0) {
 //                    handleMessage(server, event.getPlayer(), "fallingblock");

--- a/server/src/main/java/net/minestom/vanilla/server/VanillaEvents.java
+++ b/server/src/main/java/net/minestom/vanilla/server/VanillaEvents.java
@@ -5,7 +5,6 @@ import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.entity.Entity;
-import net.minestom.server.entity.GameMode;
 import net.minestom.server.entity.ItemEntity;
 import net.minestom.server.entity.Player;
 import net.minestom.server.event.Event;

--- a/server/src/main/java/net/minestom/vanilla/server/VanillaServer.java
+++ b/server/src/main/java/net/minestom/vanilla/server/VanillaServer.java
@@ -1,5 +1,6 @@
 package net.minestom.vanilla.server;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.MinecraftServer;
 import net.minestom.server.coordinate.Pos;
 import net.minestom.server.entity.GameMode;
@@ -10,8 +11,6 @@ import net.minestom.server.extras.lan.OpenToLAN;
 import net.minestom.server.instance.Instance;
 import net.minestom.server.instance.block.Block;
 import net.minestom.server.network.ConnectionManager;
-import net.minestom.server.timer.TaskSchedule;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.world.DimensionType;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.dimensions.VanillaDimensionTypes;
@@ -63,7 +62,7 @@ class VanillaServer {
         this.minecraftServer = minecraftServer;
         this.serverProperties = getOrGenerateServerProperties();
         this.vri = vri;
-        this.overworld = vri.createInstance(NamespaceID.from("world"), VanillaDimensionTypes.OVERWORLD);
+        this.overworld = vri.createInstance(Key.key("world"), VanillaDimensionTypes.OVERWORLD);
 
         // Try to get server properties
 

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/Aquifer.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/Aquifer.java
@@ -5,8 +5,8 @@ import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
 import net.minestom.vanilla.datapack.worldgen.DensityFunction;
 import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
-import net.minestom.vanilla.datapack.worldgen.util.Util;
 import net.minestom.vanilla.datapack.worldgen.random.WorldgenRandom;
+import net.minestom.vanilla.datapack.worldgen.util.Util;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/NoiseChunk.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/NoiseChunk.java
@@ -1,11 +1,12 @@
 package net.minestom.vanilla.generation;
 
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.vanilla.datapack.Datapack;
-import net.minestom.vanilla.datapack.worldgen.*;
+import net.minestom.vanilla.datapack.worldgen.DensityFunction;
+import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
@@ -71,7 +72,7 @@ public class NoiseChunk {
     }
 
     public int getPreliminarySurfaceLevel(int quartX, int quartZ) {
-        return preliminarySurfaceLevel.computeIfAbsent(ChunkUtils.getChunkIndex(quartX, quartZ), (key) -> {
+        return preliminarySurfaceLevel.computeIfAbsent(CoordConversion.chunkIndex(quartX, quartZ), (key) -> {
             int x = quartX << 2;
             int z = quartZ << 2;
             for (int y = this.settings.noise().min_y() + this.settings.noise().height(); y >= this.settings.noise().min_y(); y -= this.cellHeight) {

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/NoiseChunkGenerator.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/NoiseChunkGenerator.java
@@ -3,22 +3,19 @@ package net.minestom.vanilla.generation;
 import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import net.kyori.adventure.key.Key;
+import net.minestom.server.coordinate.CoordConversion;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.batch.ChunkBatch;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.NamespaceID;
-import net.minestom.server.utils.chunk.ChunkUtils;
 import net.minestom.server.world.DimensionType;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
 import net.minestom.vanilla.datapack.worldgen.WorldgenContext;
 import net.minestom.vanilla.datapack.worldgen.biome.BiomeSource;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 public class NoiseChunkGenerator {
@@ -131,7 +128,7 @@ public class NoiseChunkGenerator {
 //        const context = WorldgenContext.create(this.settings.noise.minY, this.settings.noise.height)
 //        randomState.surfaceSystem.buildSurface(chunk, noiseChunk, context, () => biome)
 //    }
-    public void buildSurface(Datapack datapack, RandomState randomState, TargetChunk chunk, NamespaceID biome) {
+    public void buildSurface(Datapack datapack, RandomState randomState, TargetChunk chunk, Key biome) {
         NoiseChunk noiseChunk = this.getOrCreateNoiseChunk(randomState, chunk);
         WorldgenContext context = WorldgenContext.create(this.dimensionType);
         randomState.surfaceSystem.buildSurface(chunk, noiseChunk, context, point -> biome);
@@ -223,7 +220,7 @@ public class NoiseChunkGenerator {
 
         @Override
         public @UnknownNullability Block getBlock(int x, int y, int z, @NotNull Condition condition) {
-            int index = ChunkUtils.getBlockIndex(x, y, z);
+            int index = CoordConversion.chunkBlockIndex(x, y, z);
             return this.blocks.getOrDefault(index, Block.STONE);
         }
 
@@ -232,7 +229,7 @@ public class NoiseChunkGenerator {
             if (x < minX() || x >= maxX() || y < minY() || y >= maxY() || z < minZ() || z >= maxZ()) {
                 return;
             }
-            int index = ChunkUtils.getBlockIndex(x, y, z);
+            int index = CoordConversion.chunkBlockIndex(x, y, z);
             this.blocks.put(index, block);
             batch.setBlock(x - minX(), y, z - minZ(), block);
         }
@@ -260,7 +257,7 @@ public class NoiseChunkGenerator {
         }
 
         default long index() {
-            return ChunkUtils.getChunkIndex(chunkX(), chunkZ());
+            return CoordConversion.chunkIndex(chunkX(), chunkZ());
         }
 
         int minSection();

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/RandomState.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/RandomState.java
@@ -1,6 +1,7 @@
 package net.minestom.vanilla.generation;
 
-import net.minestom.server.utils.NamespaceID;
+
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
 import net.minestom.vanilla.datapack.worldgen.biome.Climate;
 import net.minestom.vanilla.datapack.worldgen.random.LegacyRandom;
@@ -21,8 +22,8 @@ public class RandomState {
     public RandomState(NoiseSettings settings, long seed) {
         this.seed = seed;
         this.random = (settings.legacy_random_source() ? new LegacyRandom(seed) : new XoroshiroRandom(seed)).forkPositional();
-        this.aquiferRandom = this.random.fromHashOf(NamespaceID.from("aquifer").toString()).forkPositional();
-        this.oreRandom = this.random.fromHashOf(NamespaceID.from("ore").toString()).forkPositional();
+        this.aquiferRandom = this.random.fromHashOf(Key.key("aquifer").toString()).forkPositional();
+        this.oreRandom = this.random.fromHashOf(Key.key("ore").toString()).forkPositional();
         this.surfaceSystem = new SurfaceSystem(settings.surface_rule(), settings.default_block().toMinestom(), seed);
         this.router = settings.noise_router();
         this.sampler = Climate.Sampler.fromRouter(this.router);

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/SurfaceContext.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/SurfaceContext.java
@@ -1,10 +1,12 @@
 package net.minestom.vanilla.generation;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.server.world.biome.Biome;
-import net.minestom.vanilla.datapack.worldgen.*;
+import net.minestom.vanilla.datapack.worldgen.DensityFunction;
+import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
+import net.minestom.vanilla.datapack.worldgen.WorldgenContext;
 import net.minestom.vanilla.datapack.worldgen.random.WorldgenRandom;
 import net.minestom.vanilla.datapack.worldgen.util.Util;
 
@@ -21,7 +23,7 @@ public class SurfaceContext implements NoiseSettings.SurfaceRule.Context {
     public int surfaceDepth;
     public int waterHeight;
 
-    public Supplier<NamespaceID> fetchBiome = Biome.PLAINS::namespace;
+    public Supplier<Key> fetchBiome = Biome.PLAINS::key;
     public IntSupplier surfaceSecondary = () -> 0;
     public IntSupplier minSurfaceLevel = () -> 0;
 
@@ -29,10 +31,10 @@ public class SurfaceContext implements NoiseSettings.SurfaceRule.Context {
     public final NoiseChunkGenerator.TargetChunk chunk;
     public final NoiseChunk noiseChunk;
     public final WorldgenContext context;
-    private final Function<Point, NamespaceID> getBiome;
+    private final Function<Point, Key> getBiome;
 
     public SurfaceContext(SurfaceSystem system, NoiseChunkGenerator.TargetChunk chunk, NoiseChunk noiseChunk, WorldgenContext context,
-                   Function<Point, NamespaceID> getBiome) {
+                   Function<Point, Key> getBiome) {
         this.system = system;
         this.chunk = chunk;
         this.noiseChunk = noiseChunk;
@@ -72,7 +74,7 @@ public class SurfaceContext implements NoiseSettings.SurfaceRule.Context {
     }
 
     @Override
-    public NamespaceID biome() {
+    public Key biome() {
         return this.fetchBiome.get();
     }
 

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/SurfaceSystem.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/SurfaceSystem.java
@@ -1,10 +1,10 @@
 package net.minestom.vanilla.generation;
 
+import net.kyori.adventure.key.Key;
 import net.minestom.server.coordinate.Point;
 import net.minestom.server.coordinate.Vec;
 import net.minestom.server.instance.Chunk;
 import net.minestom.server.instance.block.Block;
-import net.minestom.server.utils.NamespaceID;
 import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
 import net.minestom.vanilla.datapack.worldgen.WorldgenContext;
 import net.minestom.vanilla.datapack.worldgen.WorldgenRegistries;
@@ -34,7 +34,7 @@ public class SurfaceSystem {
         this.defaultBlock = defaultBlock;
     }
 
-    public void buildSurface(NoiseChunkGenerator.TargetChunk chunk, NoiseChunk noiseChunk, WorldgenContext context, Function<Point, NamespaceID> getBiome) {
+    public void buildSurface(NoiseChunkGenerator.TargetChunk chunk, NoiseChunk noiseChunk, WorldgenContext context, Function<Point, Key> getBiome) {
         int minX = chunk.minX();
         int minZ = chunk.minZ();
         int minY = chunk.minY();

--- a/world-generation/src/main/java/net/minestom/vanilla/generation/VanillaWorldGenerationFeature.java
+++ b/world-generation/src/main/java/net/minestom/vanilla/generation/VanillaWorldGenerationFeature.java
@@ -1,16 +1,13 @@
 package net.minestom.vanilla.generation;
 
-import net.minestom.server.instance.batch.ChunkBatch;
-import net.minestom.server.utils.NamespaceID;
+import net.kyori.adventure.key.Key;
 import net.minestom.vanilla.VanillaReimplementation;
 import net.minestom.vanilla.datapack.Datapack;
 import net.minestom.vanilla.datapack.DatapackLoadingFeature;
 import net.minestom.vanilla.datapack.worldgen.NoiseSettings;
 import net.minestom.vanilla.instance.SetupVanillaInstanceEvent;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.List;
 import java.util.Set;
 
 public class VanillaWorldGenerationFeature implements VanillaReimplementation.Feature {
@@ -19,7 +16,7 @@ public class VanillaWorldGenerationFeature implements VanillaReimplementation.Fe
     public void hook(@NotNull HookContext context) {
         context.vri().process().eventHandler().addListener(SetupVanillaInstanceEvent.class, event -> {
 
-            NamespaceID plains = NamespaceID.from("minecraft:plains");
+            Key plains = Key.key("minecraft:plains");
             DatapackLoadingFeature datapackLoading = context.vri().feature(DatapackLoadingFeature.class);
             Datapack datapack = datapackLoading.current();
 
@@ -47,8 +44,8 @@ public class VanillaWorldGenerationFeature implements VanillaReimplementation.Fe
     }
 
     @Override
-    public @NotNull NamespaceID namespaceId() {
-        return NamespaceID.from("vri:worldgeneration");
+    public @NotNull Key key() {
+        return Key.key("vri:worldgeneration");
     }
 
     @Override


### PR DESCRIPTION
Hi! I decided to take a stab at updating VRI to 1.21.5. This PR is still a work-in-progress, but I wanted to share it early. If anyone wants to contribute, feel free to open a PR at [BlueDragonMC/VanillaReimplementation](https://github.com/BlueDragonMC/VanillaReimplementation/). Everything compiles, but much more manual testing is needed before I can confirm that everything is working properly.

Major changes:
- `NamespaceID` -> `Key`
- Changed `window`'s package name
- Minestom's 1.21.2 [recipe changes](https://gist.github.com/mworzala/69eb0a3e16b74b5a4959c69d82b70264#recipe-changes)
- Various Minestom refactoring: `FloatRange` -> `Range.Float`, `ChunkUtils` -> `CoordConversion`, `Entity.Pose` -> `EntityPose`, `Player.Hand` -> `PlayerHand`, `PacketUtils` -> `PacketSendingUtils`, etc.

Here are all the issues I've found so far.
- [ ] TNT explosions don't work
- [ ] Stonecutter recipes appear, but clicking on one sometimes fills in the result slot with the result of a different recipe
- [ ] Water flow doesn't work
- [ ] Lighting a nether portal doesn't work
- [ ] Ore smelting recipes aren't grouped in the recipe book
- [ ] When a falling block lands on a chest, it drops a chest instead of the entity's block type

Here are the features I've tested. If an item is checked here, then it's working or the bugs I've found have been added to the list above.
- [ ] `block-update-system`
   - [ ] Random ticks
- [ ] `blocks`
  - [x] Chest
  - [x] Bed
  - [ ] Cake
  - [ ] Concrete powder
  - [ ] Ender chest
  - [ ] Trapped chest
  - [ ] End portal
  - [x] Gravity blocks (sand, gravel)
  - [x] Jukebox
  - [ ] TNT
  - [ ] Block loot from loot tables
  - [ ] Copper oxidization
  - [x] Crafting menus (furnace, crafting table, stonecutter, smoker, etc)
- [ ] `commands`
- [ ] `crafting`
  - [x] Crafting table and survival inventory crafting
  - [x] Recipe book (crafting table, furnace, smoker, blast furnace)
  - [ ] Stonecutter
  - [ ] Smithing table
  - [ ] Furnace
  - [ ] Blast furnace
  - [ ] Smoker
- [x] `datapack-loading` (loads 1.21.5 data successfully on startup)
- [x] `datapack-tests` (all pass)
- [x] `entities`
  - [x] Falling blocks
  - [x] Primed TNT
- [x] `entity-meta` (nothing to test?)
- [ ] `fluid-simulation`
- [ ] `instance-meta` (unsure how to test)
- [x] `item-placeables` (water and lava buckets)
- [x] `items` (flint and steel)
- [x] `world-generation`

Fixes #56